### PR TITLE
Terminate AsyncLLMEngine task gracefully

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -118,6 +118,10 @@ class TritonPythonModel:
             )
             await asyncio.sleep(5)
 
+        for task in asyncio.all_tasks(loop=self._loop):
+            if task is not asyncio.current_task():
+                task.cancel()
+
         self.logger.log_info("Shutdown complete")
 
     def get_sampling_params_dict(self, params_json):


### PR DESCRIPTION
Cleanup the following task running forever.
```
task: <Task pending name='Task-3' coro=<AsyncLLMEngine.run_engine_loop() running at /usr/local/lib/python3.10/dist-packages/vllm/engine/async_llm_engine.py:350> wait_for=<Future pending cb=[Task.task_wakeup()]>
```