### PR TITLE
Adding autocomplete to vllm model.py

### DIFF
--- a/ci/L0_backend_vllm/accuracy_test/accuracy_test.py
+++ b/ci/L0_backend_vllm/accuracy_test/accuracy_test.py
@@ -90,7 +90,6 @@ class VLLMTritonAccuracyTest(TestResultCollector):
             request_data = create_vllm_request(
                 prompts[i], i, stream, sampling_parameters, self.vllm_model_name
             )
-            print(request_data["inputs"])
             self.triton_client.async_stream_infer(
                 model_name=self.vllm_model_name,
                 request_id=request_data["request_id"],

--- a/ci/L0_backend_vllm/accuracy_test/accuracy_test.py
+++ b/ci/L0_backend_vllm/accuracy_test/accuracy_test.py
@@ -90,6 +90,7 @@ class VLLMTritonAccuracyTest(TestResultCollector):
             request_data = create_vllm_request(
                 prompts[i], i, stream, sampling_parameters, self.vllm_model_name
             )
+            print(request_data["inputs"])
             self.triton_client.async_stream_infer(
                 model_name=self.vllm_model_name,
                 request_id=request_data["request_id"],
@@ -104,10 +105,10 @@ class VLLMTritonAccuracyTest(TestResultCollector):
 
         for i in range(number_of_vllm_reqs):
             result = user_data._completed_requests.get()
-            self.assertIsNot(type(result), InferenceServerException)
+            self.assertIsNot(type(result), InferenceServerException, str(result))
 
             output = result.as_numpy("text_output")
-            self.assertIsNotNone(output)
+            self.assertIsNotNone(output, "`text_output` should not be None")
 
             triton_vllm_output.extend(output)
 

--- a/ci/L0_backend_vllm/enabled_stream/enabled_stream_test.py
+++ b/ci/L0_backend_vllm/enabled_stream/enabled_stream_test.py
@@ -40,7 +40,7 @@ class VLLMTritonStreamTest(AsyncTestResultCollector):
         async with grpcclient.InferenceServerClient(
             url="localhost:8001"
         ) as triton_client:
-            model_name = "vllm_opt"
+            model_name = "vllm_model"
             stream = True
             prompts = [
                 "The most dangerous animal is",
@@ -64,7 +64,7 @@ class VLLMTritonStreamTest(AsyncTestResultCollector):
                 self.assertIsNotNone(result, str(result))
 
                 output = result.as_numpy("text_output")
-                self.assertIsNotNone(output)
+                self.assertIsNotNone(output, "`text_output` should not be None")
 
 
 if __name__ == "__main__":

--- a/ci/L0_backend_vllm/enabled_stream/enabled_stream_test.py
+++ b/ci/L0_backend_vllm/enabled_stream/enabled_stream_test.py
@@ -40,7 +40,7 @@ class VLLMTritonStreamTest(AsyncTestResultCollector):
         async with grpcclient.InferenceServerClient(
             url="localhost:8001"
         ) as triton_client:
-            model_name = "vllm_model"
+            model_name = "vllm_opt"
             stream = True
             prompts = [
                 "The most dangerous animal is",

--- a/ci/L0_backend_vllm/enabled_stream/enabled_stream_test.py
+++ b/ci/L0_backend_vllm/enabled_stream/enabled_stream_test.py
@@ -60,8 +60,8 @@ class VLLMTritonStreamTest(AsyncTestResultCollector):
 
             async for response in response_iterator:
                 result, error = response
-                self.assertIsNone(error)
-                self.assertIsNotNone(result)
+                self.assertIsNone(error, str(error))
+                self.assertIsNotNone(result, str(result))
 
                 output = result.as_numpy("text_output")
                 self.assertIsNotNone(output)

--- a/ci/L0_backend_vllm/vllm_backend/vllm_backend_test.py
+++ b/ci/L0_backend_vllm/vllm_backend/vllm_backend_test.py
@@ -107,10 +107,10 @@ class VLLMTritonBackendTest(TestResultCollector):
             result = user_data._completed_requests.get()
             if type(result) is InferenceServerException:
                 print(result.message())
-            self.assertIsNot(type(result), InferenceServerException)
+            self.assertIsNot(type(result), InferenceServerException, str(result))
 
             output = result.as_numpy("text_output")
-            self.assertIsNotNone(output)
+            self.assertIsNotNone(output, "`text_output` should not be None")
 
         self.triton_client.stop_stream()
 

--- a/samples/model_repository/vllm_model/config.pbtxt
+++ b/samples/model_repository/vllm_model/config.pbtxt
@@ -28,6 +28,18 @@
 
 backend: "vllm"
 
+# Disabling batching in Triton, let vLLM handle the batching on its own.
+max_batch_size: 0
+
+# We need to use decoupled transaction policy for saturating
+# vLLM engine for max throughtput.
+# TODO [DLIS:5233]: Allow asynchronous execution to lift this
+# restriction for cases there is exactly a single response to
+# a single request.
+model_transaction_policy {
+  decoupled: True
+}
+
 # The usage of device is deferred to the vLLM engine
 instance_group [
   {

--- a/samples/model_repository/vllm_model/config.pbtxt
+++ b/samples/model_repository/vllm_model/config.pbtxt
@@ -28,6 +28,46 @@
 
 backend: "vllm"
 
+# Disabling batching in Triton, let vLLM handle the batching on its own.
+max_batch_size: 0
+
+# We need to use decoupled transaction policy for saturating
+# vLLM engine for max throughtput.
+# TODO [DLIS:5233]: Allow asynchronous execution to lift this
+# restriction for cases there is exactly a single response to
+# a single request.
+model_transaction_policy {
+  decoupled: True
+}
+# Note: The vLLM backend uses the following input and output names.
+# Any change here needs to also be made in model.py
+input [
+  {
+    name: "text_input"
+    data_type: TYPE_STRING
+    dims: [ 1 ]
+  },
+  {
+    name: "stream"
+    data_type: TYPE_BOOL
+    dims: [ 1 ]
+  },
+  {
+    name: "sampling_parameters"
+    data_type: TYPE_STRING
+    dims: [ 1 ]
+    optional: true
+  }
+]
+
+output [
+  {
+    name: "text_output"
+    data_type: TYPE_STRING
+    dims: [ -1 ]
+  }
+]
+
 # The usage of device is deferred to the vLLM engine
 instance_group [
   {

--- a/samples/model_repository/vllm_model/config.pbtxt
+++ b/samples/model_repository/vllm_model/config.pbtxt
@@ -28,18 +28,6 @@
 
 backend: "vllm"
 
-# Disabling batching in Triton, let vLLM handle the batching on its own.
-max_batch_size: 0
-
-# We need to use decoupled transaction policy for saturating
-# vLLM engine for max throughtput.
-# TODO [DLIS:5233]: Allow asynchronous execution to lift this
-# restriction for cases there is exactly a single response to
-# a single request.
-model_transaction_policy {
-  decoupled: True
-}
-
 # The usage of device is deferred to the vLLM engine
 instance_group [
   {

--- a/samples/model_repository/vllm_model/config.pbtxt
+++ b/samples/model_repository/vllm_model/config.pbtxt
@@ -28,46 +28,6 @@
 
 backend: "vllm"
 
-# Disabling batching in Triton, let vLLM handle the batching on its own.
-max_batch_size: 0
-
-# We need to use decoupled transaction policy for saturating
-# vLLM engine for max throughtput.
-# TODO [DLIS:5233]: Allow asynchronous execution to lift this
-# restriction for cases there is exactly a single response to
-# a single request.
-model_transaction_policy {
-  decoupled: True
-}
-# Note: The vLLM backend uses the following input and output names.
-# Any change here needs to also be made in model.py
-input [
-  {
-    name: "text_input"
-    data_type: TYPE_STRING
-    dims: [ 1 ]
-  },
-  {
-    name: "stream"
-    data_type: TYPE_BOOL
-    dims: [ 1 ]
-  },
-  {
-    name: "sampling_parameters"
-    data_type: TYPE_STRING
-    dims: [ 1 ]
-    optional: true
-  }
-]
-
-output [
-  {
-    name: "text_output"
-    data_type: TYPE_STRING
-    dims: [ -1 ]
-  }
-]
-
 # The usage of device is deferred to the vLLM engine
 instance_group [
   {

--- a/src/model.py
+++ b/src/model.py
@@ -41,49 +41,6 @@ _VLLM_ENGINE_ARGS_FILENAME = "model.json"
 
 
 class TritonPythonModel:
-    @staticmethod
-    def auto_complete_config(auto_complete_model_config):
-        inputs = [
-            {"name": "text_input", "data_type": "TYPE_STRING", "dims": [1]},
-            {"name": "stream", "data_type": "TYPE_BOOL", "dims": [1]},
-            {
-                "name": "sampling_parameters",
-                "data_type": "TYPE_STRING",
-                "dims": [1],
-                "optional": True,
-            },
-        ]
-        outputs = [{"name": "text_output", "data_type": "TYPE_STRING", "dims": [-1]}]
-
-        # Store the model configuration as a dictionary.
-        config = auto_complete_model_config.as_dict()
-        input_names = []
-        output_names = []
-        for input in config["input"]:
-            input_names.append(input["name"])
-        for output in config["output"]:
-            output_names.append(output["name"])
-
-        # Add only missing inputs and output to the model configuration.
-        for input in inputs:
-            if input["name"] not in input_names:
-                auto_complete_model_config.add_input(input)
-        for output in outputs:
-            if output["name"] not in output_names:
-                auto_complete_model_config.add_output(output)
-
-        # We need to use decoupled transaction policy for saturating
-        # vLLM engine for max throughtput.
-        # TODO [DLIS:5233]: Allow asynchronous execution to lift this
-        # restriction for cases there is exactly a single response to
-        # a single request.
-        auto_complete_model_config.set_model_transaction_policy(dict(decoupled=True))
-
-        # Disabling batching in Triton, let vLLM handle the batching on its own.
-        auto_complete_model_config.set_max_batch_size(0)
-
-        return auto_complete_model_config
-
     def initialize(self, args):
         self.logger = pb_utils.Logger
         self.model_config = json.loads(args["model_config"])

--- a/src/model.py
+++ b/src/model.py
@@ -72,6 +72,13 @@ class TritonPythonModel:
             if output["name"] not in output_names:
                 auto_complete_model_config.add_output(output)
 
+        # We need to use decoupled transaction policy for saturating
+        # vLLM engine for max throughtput.
+        # TODO [DLIS:5233]: Allow asynchronous execution to lift this
+        # restriction for cases there is exactly a single response to
+        # a single request.
+        auto_complete_model_config.set_model_transaction_policy(dict(decoupled=True))
+
         # Disabling batching in Triton, let vLLM handle the batching on its own.
         auto_complete_model_config.set_max_batch_size(0)
 

--- a/src/model.py
+++ b/src/model.py
@@ -41,6 +41,49 @@ _VLLM_ENGINE_ARGS_FILENAME = "model.json"
 
 
 class TritonPythonModel:
+    @staticmethod
+    def auto_complete_config(auto_complete_model_config):
+        inputs = [
+            {"name": "text_input", "data_type": "TYPE_STRING", "dims": [1]},
+            {"name": "stream", "data_type": "TYPE_BOOL", "dims": [1]},
+            {
+                "name": "sampling_parameters",
+                "data_type": "TYPE_STRING",
+                "dims": [1],
+                "optional": True,
+            },
+        ]
+        outputs = [{"name": "text_output", "data_type": "TYPE_STRING", "dims": [-1]}]
+
+        # Store the model configuration as a dictionary.
+        config = auto_complete_model_config.as_dict()
+        input_names = []
+        output_names = []
+        for input in config["input"]:
+            input_names.append(input["name"])
+        for output in config["output"]:
+            output_names.append(output["name"])
+
+        # Add only missing inputs and output to the model configuration.
+        for input in inputs:
+            if input["name"] not in input_names:
+                auto_complete_model_config.add_input(input)
+        for output in outputs:
+            if output["name"] not in output_names:
+                auto_complete_model_config.add_output(output)
+
+        # We need to use decoupled transaction policy for saturating
+        # vLLM engine for max throughtput.
+        # TODO [DLIS:5233]: Allow asynchronous execution to lift this
+        # restriction for cases there is exactly a single response to
+        # a single request.
+        auto_complete_model_config.set_model_transaction_policy(dict(decoupled=True))
+
+        # Disabling batching in Triton, let vLLM handle the batching on its own.
+        auto_complete_model_config.set_max_batch_size(0)
+
+        return auto_complete_model_config
+
     def initialize(self, args):
         self.logger = pb_utils.Logger
         self.model_config = json.loads(args["model_config"])

--- a/src/model.py
+++ b/src/model.py
@@ -72,13 +72,6 @@ class TritonPythonModel:
             if output["name"] not in output_names:
                 auto_complete_model_config.add_output(output)
 
-        # We need to use decoupled transaction policy for saturating
-        # vLLM engine for max throughtput.
-        # TODO [DLIS:5233]: Allow asynchronous execution to lift this
-        # restriction for cases there is exactly a single response to
-        # a single request.
-        auto_complete_model_config.set_model_transaction_policy(dict(decoupled=True))
-
         # Disabling batching in Triton, let vLLM handle the batching on its own.
         auto_complete_model_config.set_max_batch_size(0)
 

--- a/src/model.py
+++ b/src/model.py
@@ -48,7 +48,7 @@ class TritonPythonModel:
             {"name": "stream", "data_type": "TYPE_BOOL", "dims": [1]},
             {
                 "name": "sampling_parameters",
-                "TYPE_STRING": "TYPE_FP32",
+                "data_type": "TYPE_STRING",
                 "dims": [1],
                 "optional": True,
             },

--- a/src/model.py
+++ b/src/model.py
@@ -41,6 +41,49 @@ _VLLM_ENGINE_ARGS_FILENAME = "model.json"
 
 
 class TritonPythonModel:
+    @staticmethod
+    def auto_complete_config(auto_complete_model_config):
+        inputs = [
+            {"name": "text_input", "data_type": "TYPE_STRING", "dims": [1]},
+            {"name": "stream", "data_type": "TYPE_BOOL", "dims": [1]},
+            {
+                "name": "sampling_parameters",
+                "TYPE_STRING": "TYPE_FP32",
+                "dims": [1],
+                "optional": True,
+            },
+        ]
+        outputs = [{"name": "text_output", "data_type": "TYPE_STRING", "dims": [-1]}]
+
+        # Store the model configuration as a dictionary.
+        config = auto_complete_model_config.as_dict()
+        input_names = []
+        output_names = []
+        for input in config["input"]:
+            input_names.append(input["name"])
+        for output in config["output"]:
+            output_names.append(output["name"])
+
+        # Add only missing inputs and output to the model configuration.
+        for input in inputs:
+            if input["name"] not in input_names:
+                auto_complete_model_config.add_input(input)
+        for output in outputs:
+            if output["name"] not in output_names:
+                auto_complete_model_config.add_output(output)
+
+        # We need to use decoupled transaction policy for saturating
+        # vLLM engine for max throughtput.
+        # TODO [DLIS:5233]: Allow asynchronous execution to lift this
+        # restriction for cases there is exactly a single response to
+        # a single request.
+        auto_complete_model_config.set_model_transaction_policy(dict(decoupled=True))
+
+        # Disabling batching in Triton, let vLLM handle the batching on its own.
+        auto_complete_model_config.set_max_batch_size(0)
+
+        return auto_complete_model_config
+
     def initialize(self, args):
         self.logger = pb_utils.Logger
         self.model_config = json.loads(args["model_config"])

--- a/src/model.py
+++ b/src/model.py
@@ -45,7 +45,12 @@ class TritonPythonModel:
     def auto_complete_config(auto_complete_model_config):
         inputs = [
             {"name": "text_input", "data_type": "TYPE_STRING", "dims": [1]},
-            {"name": "stream", "data_type": "TYPE_BOOL", "dims": [1]},
+            {
+                "name": "stream",
+                "data_type": "TYPE_BOOL",
+                "dims": [1],
+                "optional": True,
+            },
             {
                 "name": "sampling_parameters",
                 "data_type": "TYPE_STRING",


### PR DESCRIPTION
Moving default parameters from config to auto_complete function.

Also tests Python_backend's `set_model_transaction_policy` 