### PR TITLE
Why prepending output with prompt?

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -213,7 +213,7 @@ class TritonPythonModel:
         """
         prompt = vllm_output.prompt
         text_outputs = [
-            (prompt + output.text).encode("utf-8") for output in vllm_output.outputs
+            output.text.encode("utf-8") for output in vllm_output.outputs
         ]
         triton_output_tensor = pb_utils.Tensor(
             "text_output", np.asarray(text_outputs, dtype=self.output_dtype)


### PR DESCRIPTION
I'd rather created issue for discussion, but this repo doesn't have issues enabled.  First of all such prepending seems redundant especially for long RAG prompts. Then, it's an actual problem since I notice that triton gRPC crops the long response. Curiously, REST doesn't crop payload and full concatenation of prompt and output arrives to client. 

Here I put more details of the issue https://github.com/langchain-ai/langchain/issues/12474#issuecomment-1925914483