### PR TITLE
Add `exclude_input_in_output` option to vllm backend

### DIFF
--- a/ci/L0_backend_vllm/enabled_stream/test.sh
+++ b/ci/L0_backend_vllm/enabled_stream/test.sh
@@ -36,7 +36,7 @@ CLIENT_LOG="./enabled_stream_client.log"
 TEST_RESULT_FILE='test_results.txt'
 CLIENT_PY="./enabled_stream_test.py"
 SAMPLE_MODELS_REPO="../../../samples/model_repository"
-EXPECTED_NUM_TESTS=1
+EXPECTED_NUM_TESTS=3
 
 rm -rf models && mkdir -p models
 cp -r ${SAMPLE_MODELS_REPO}/vllm_model models/vllm_opt

--- a/ci/L0_backend_vllm/vllm_backend/test.sh
+++ b/ci/L0_backend_vllm/vllm_backend/test.sh
@@ -36,7 +36,7 @@ CLIENT_LOG="./vllm_backend_client.log"
 TEST_RESULT_FILE='test_results.txt'
 CLIENT_PY="./vllm_backend_test.py"
 SAMPLE_MODELS_REPO="../../../samples/model_repository"
-EXPECTED_NUM_TESTS=3
+EXPECTED_NUM_TESTS=6
 
 # Helpers =======================================
 function assert_curl_success {

--- a/ci/common/test_util.py
+++ b/ci/common/test_util.py
@@ -95,6 +95,7 @@ def create_vllm_request(
     sampling_parameters,
     model_name,
     send_parameters_as_tensor=True,
+    exclude_input_in_output=None,
 ):
     inputs = []
 
@@ -110,6 +111,10 @@ def create_vllm_request(
         )
         inputs.append(grpcclient.InferInput("sampling_parameters", [1], "BYTES"))
         inputs[-1].set_data_from_numpy(sampling_parameters_data)
+
+    if exclude_input_in_output is not None:
+        inputs.append(grpcclient.InferInput("exclude_input_in_output", [1], "BOOL"))
+        inputs[-1].set_data_from_numpy(np.array([exclude_input_in_output], dtype=bool))
 
     outputs = [grpcclient.InferRequestedOutput("text_output")]
 

--- a/samples/client.py
+++ b/samples/client.py
@@ -45,7 +45,9 @@ class LLMClient:
         self._loop = asyncio.get_event_loop()
         self._results_dict = {}
 
-    async def async_request_iterator(self, prompts, sampling_parameters):
+    async def async_request_iterator(
+        self, prompts, sampling_parameters, exclude_input_in_output
+    ):
         try:
             for iter in range(self._flags.iterations):
                 for i, prompt in enumerate(prompts):
@@ -56,16 +58,17 @@ class LLMClient:
                         self._flags.streaming_mode,
                         prompt_id,
                         sampling_parameters,
+                        exclude_input_in_output,
                     )
         except Exception as error:
             print(f"Caught an error in the request iterator: {error}")
 
-    async def stream_infer(self, prompts, sampling_parameters):
+    async def stream_infer(self, prompts, sampling_parameters, exclude_input_in_output):
         try:
             # Start streaming
             response_iterator = self._client.stream_infer(
                 inputs_iterator=self.async_request_iterator(
-                    prompts, sampling_parameters
+                    prompts, sampling_parameters, exclude_input_in_output
                 ),
                 stream_timeout=self._flags.stream_timeout,
             )
@@ -75,33 +78,43 @@ class LLMClient:
             print(error)
             sys.exit(1)
 
-    async def process_stream(self, prompts, sampling_parameters):
+    async def process_stream(
+        self, prompts, sampling_parameters, exclude_input_in_output
+    ):
         # Clear results in between process_stream calls
         self.results_dict = []
-
+        success = True
         # Read response from the stream
-        async for response in self.stream_infer(prompts, sampling_parameters):
+        async for response in self.stream_infer(
+            prompts, sampling_parameters, exclude_input_in_output
+        ):
             result, error = response
             if error:
                 print(f"Encountered error while processing: {error}")
+                success = False
             else:
                 output = result.as_numpy("text_output")
                 for i in output:
                     self._results_dict[result.get_response().id].append(i)
+        return success
 
     async def run(self):
+        exclude_input_in_output = self._flags.exclude_inputs_in_outputs
         sampling_parameters = {"temperature": "0.1", "top_p": "0.95"}
         with open(self._flags.input_prompts, "r") as file:
             print(f"Loading inputs from `{self._flags.input_prompts}`...")
             prompts = file.readlines()
 
-        await self.process_stream(prompts, sampling_parameters)
+        success = await self.process_stream(
+            prompts, sampling_parameters, exclude_input_in_output
+        )
 
         with open(self._flags.results_file, "w") as file:
             for id in self._results_dict.keys():
                 for result in self._results_dict[id]:
                     file.write(result.decode("utf-8"))
-                    file.write("\n")
+
+                file.write("\n")
                 file.write("\n=========\n\n")
             print(f"Storing results into `{self._flags.results_file}`...")
 
@@ -109,8 +122,10 @@ class LLMClient:
             with open(self._flags.results_file, "r") as file:
                 print(f"\nContents of `{self._flags.results_file}` ===>")
                 print(file.read())
-
-        print("PASS: vLLM example")
+        if success:
+            print("PASS: vLLM example")
+        else:
+            print("FAIL: vLLM example")
 
     def run_async(self):
         self._loop.run_until_complete(self.run())
@@ -121,6 +136,7 @@ class LLMClient:
         stream,
         request_id,
         sampling_parameters,
+        exclude_input_in_output,
         send_parameters_as_tensor=True,
     ):
         inputs = []
@@ -145,6 +161,9 @@ class LLMClient:
             )
             inputs.append(grpcclient.InferInput("sampling_parameters", [1], "BYTES"))
             inputs[-1].set_data_from_numpy(sampling_parameters_data)
+
+        inputs.append(grpcclient.InferInput("exclude_input_in_output", [1], "BOOL"))
+        inputs[-1].set_data_from_numpy(np.array([exclude_input_in_output], dtype=bool))
 
         # Add requested outputs
         outputs = []
@@ -229,6 +248,13 @@ if __name__ == "__main__":
         required=False,
         default=False,
         help="Enable streaming mode",
+    )
+    parser.add_argument(
+        "--exclude-inputs-in-outputs",
+        action="store_true",
+        required=False,
+        default=False,
+        help="Exclude prompt from outputs",
     )
     FLAGS = parser.parse_args()
 

--- a/src/model.py
+++ b/src/model.py
@@ -273,11 +273,12 @@ class TritonPythonModel:
             else:
                 exclude_input_in_output = False
 
-            self.logger.log_info(
-                "[vllm] `exclude_input_in_output` is set to {}".format(
-                    exclude_input_in_output
+            if not exclude_input_in_output and stream:
+                exclude_input_in_output = True
+                self.logger.log_info(
+                    "[vllm] When streaming, `exclude_input_in_output` = False \
+                    is not allowed. Setting `exclude_input_in_output` to True."
                 )
-            )
 
             # Request parameters are not yet supported via
             # BLS. Provide an optional mechanism to receive serialized

--- a/src/model.py
+++ b/src/model.py
@@ -61,7 +61,7 @@ class TritonPythonModel:
                 "name": "exclude_input_in_output",
                 "data_type": "TYPE_BOOL",
                 "dims": [1],
-                "optional": True,
+                "optional": False,
             },
         ]
         outputs = [{"name": "text_output", "data_type": "TYPE_STRING", "dims": [-1]}]
@@ -272,6 +272,12 @@ class TritonPythonModel:
                 exclude_input_in_output = True
             else:
                 exclude_input_in_output = False
+
+            self.logger.log_info(
+                "[vllm] `exclude_input_in_output` is set to {}".format(
+                    exclude_input_in_output
+                )
+            )
 
             # Request parameters are not yet supported via
             # BLS. Provide an optional mechanism to receive serialized


### PR DESCRIPTION
This PR adds `exclude_input_in_output` flag to vllm backend inputs.
It only impacts non-streaming case.
For streaming case, I refactored code and return only `diffs`, e.g.:
Prompt = "The most dangerous animal is"
Response:
```
" the",
            " one",
            " that",
            " is",
            " most",
            " likely",
            " to",
            " be",
            " killed",
            " by",
            " a",
            " car",
            ".",
```
The above case will be the only possible response in the streaming mode. Open to discussions.
cc @@mkhludnev
