### PR TITLE
fix: Enhance checks around KIND_GPU and tensor parallelism

### DIFF
--- a/ci/L0_multi_gpu/vllm_backend/vllm_multi_gpu_test.py
+++ b/ci/L0_multi_gpu/vllm_backend/vllm_multi_gpu_test.py
@@ -26,7 +26,6 @@
 
 import os
 import sys
-import time
 import unittest
 from functools import partial
 

--- a/src/model.py
+++ b/src/model.py
@@ -1,4 +1,4 @@
-# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -28,16 +28,18 @@ import asyncio
 import json
 import os
 import threading
-from typing import AsyncGenerator
+from typing import Dict, List
 
 import numpy as np
 import triton_python_backend_utils as pb_utils
-from vllm import SamplingParams
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine
+from vllm.lora.request import LoRARequest
+from vllm.sampling_params import SamplingParams
 from vllm.utils import random_uuid
 
 _VLLM_ENGINE_ARGS_FILENAME = "model.json"
+_MULTI_LORA_ARGS_FILENAME = "multi_lora.json"
 
 
 class TritonPythonModel:
@@ -96,12 +98,53 @@ class TritonPythonModel:
         return auto_complete_model_config
 
     def initialize(self, args):
-        self.args = args
         self.logger = pb_utils.Logger
         self.model_config = json.loads(args["model_config"])
 
-        # Prepare vLLM engine
-        self.init_engine()
+        # assert are in decoupled mode. Currently, Triton needs to use
+        # decoupled policy for asynchronously forwarding requests to
+        # vLLM engine.
+        self.using_decoupled = pb_utils.using_decoupled_model_transaction_policy(
+            self.model_config
+        )
+        assert (
+            self.using_decoupled
+        ), "vLLM Triton backend must be configured to use decoupled model transaction policy"
+
+        engine_args_filepath = os.path.join(
+            pb_utils.get_model_dir(), _VLLM_ENGINE_ARGS_FILENAME
+        )
+        assert os.path.isfile(
+            engine_args_filepath
+        ), f"'{_VLLM_ENGINE_ARGS_FILENAME}' containing vllm engine args must be provided in '{pb_utils.get_model_dir()}'"
+        with open(engine_args_filepath) as file:
+            vllm_engine_config = json.load(file)
+
+        # Create an AsyncLLMEngine from the config from JSON
+        self.llm_engine = AsyncLLMEngine.from_engine_args(
+            AsyncEngineArgs(**vllm_engine_config)
+        )
+        self.enable_lora = False
+
+        if (
+            "enable_lora" in vllm_engine_config.keys()
+            and vllm_engine_config["enable_lora"].lower() == "true"
+        ):
+            # create Triton LoRA weights repository
+            multi_lora_args_filepath = os.path.join(
+                pb_utils.get_model_dir(), _MULTI_LORA_ARGS_FILENAME
+            )
+            try:
+                with open(multi_lora_args_filepath) as lora_file:
+                    lora_repository: Dict[str, str] = json.load(lora_file)
+                self.lora_repository = lora_repository
+                self.supported_loras: List[str] = list(self.lora_repository.keys())
+                self.supported_loras_len = len(self.supported_loras)
+                self.enable_lora = True
+            except FileNotFoundError:
+                raise FileNotFoundError(
+                    f"Triton backend cannot find {multi_lora_args_filepath}."
+                )
 
         output_config = pb_utils.get_output_config_by_name(
             self.model_config, "text_output"
@@ -118,61 +161,6 @@ class TritonPythonModel:
         )
         self._shutdown_event = asyncio.Event()
         self._loop_thread.start()
-
-    def init_engine(self):
-        # Currently, Triton needs to use decoupled policy for asynchronously
-        # forwarding requests to vLLM engine, so assert it.
-        self.using_decoupled = pb_utils.using_decoupled_model_transaction_policy(
-            self.model_config
-        )
-        assert (
-            self.using_decoupled
-        ), "vLLM Triton backend must be configured to use decoupled model transaction policy"
-
-        # Parse user-provided vLLM config
-        engine_args_filepath = os.path.join(
-            pb_utils.get_model_dir(), _VLLM_ENGINE_ARGS_FILENAME
-        )
-        assert os.path.isfile(
-            engine_args_filepath
-        ), f"'{_VLLM_ENGINE_ARGS_FILENAME}' containing vllm engine args must be provided in '{pb_utils.get_model_dir()}'"
-
-        with open(engine_args_filepath) as file:
-            vllm_engine_config = json.load(file)
-
-        # Validate device and multi-processing settings are currently set based on model/configs.
-        self.validate_device_config(vllm_engine_config)
-
-        # Create an AsyncLLMEngine from the config from JSON
-        self.llm_engine = AsyncLLMEngine.from_engine_args(
-            AsyncEngineArgs(**vllm_engine_config)
-        )
-
-    def validate_device_config(self, vllm_engine_config):
-        triton_kind = self.args["model_instance_kind"]
-        triton_device_id = self.args["model_instance_device_id"]
-        triton_instance = f"{self.args['model_name']}_{triton_device_id}"
-
-        # Triton's current definition of KIND_GPU makes assumptions that
-        # models only use a single GPU. For multi-GPU models, the recommendation
-        # is to specify KIND_MODEL to acknowledge that the model will take control
-        # of the devices made available to it.
-        # NOTE: Consider other parameters that would indicate multi-GPU in the future.
-        tp_size = int(vllm_engine_config.get("tensor_parallel_size", 1))
-        if tp_size > 1 and triton_kind == "GPU":
-            raise ValueError(
-                "KIND_GPU is for single-GPU models, please specify KIND_MODEL in the model's config.pbtxt for multi-GPU models"
-            )
-
-        # If KIND_GPU is specified, isolate the selected GPU device to ensure that multiple model instances do not all use the same default
-        # device (usually device 0) when KIND_GPU is used.
-        if triton_kind == "GPU" and int(triton_device_id) >= 0:
-            self.logger.log_info(
-                f"Detected KIND_GPU model instance, explicitly setting GPU device={triton_device_id} for {triton_instance}"
-            )
-            # NOTE: this only affects this process and it's subprocesses, not other processes.
-            # vLLM doesn't currently seem to expose selecting a specific device in the APIs.
-            os.environ["CUDA_VISIBLE_DEVICES"] = triton_device_id
 
     def create_task(self, coro):
         """
@@ -331,12 +319,19 @@ class TritonPythonModel:
                 parameters = request.parameters()
 
             sampling_params_dict = self.get_sampling_params_dict(parameters)
+            lora_name = sampling_params_dict.pop("lora_name", None)
             sampling_params = SamplingParams(**sampling_params_dict)
-
             last_output = None
             prev_outputs = None
+            lora_request = None
+            if lora_name is not None:
+                lora_id = str(self.supported_loras.index(lora_name) + 1)
+                lora_int_id = int(lora_id)
+                lora_local_path = self.lora_repository[lora_name]
+                lora_request = LoRARequest(lora_id, lora_int_id, lora_local_path)
+
             async for output in self.llm_engine.generate(
-                prompt, sampling_params, request_id
+                prompt, sampling_params, request_id, lora_request=lora_request
             ):
                 if response_sender.is_cancelled():
                     self.logger.log_info("[vllm] Cancelling the request")
@@ -385,6 +380,49 @@ class TritonPythonModel:
         finally:
             self.ongoing_request_count -= 1
 
+    def verify_loras(self, request):
+        # We will check if the requested lora exists here, if not we will send a
+        # response with `LoRA not found` information. In this way we may avoid
+        # further processing.
+        verified_request = None
+        lora_error = None
+        lora_name = None
+        parameters_input_tensor = pb_utils.get_input_tensor_by_name(
+            request, "sampling_parameters"
+        )
+        if parameters_input_tensor:
+            parameters = parameters_input_tensor.as_numpy()[0].decode("utf-8")
+            sampling_params_dict = self.get_sampling_params_dict(parameters)
+            lora_name = sampling_params_dict.pop("lora_name", None)
+
+        if lora_name is not None:
+            if not self.enable_lora:
+                lora_error = pb_utils.TritonError("LoRA feature is not enabled.")
+                self.logger.log_info(
+                    "[vllm] LoRA is not enabled, please restart the backend with LoRA enabled."
+                )
+            elif lora_name not in self.supported_loras:
+                lora_error = pb_utils.TritonError(
+                    f"LoRA {lora_name} is not supported, we currently support {self.supported_loras}"
+                )
+                self.logger.log_info(f"[vllm] LoRA {lora_name} not found.")
+
+        if lora_error is not None:
+            output_tensor = pb_utils.Tensor(
+                "text_output",
+                np.asarray(["[Error] Unsupported LoRA."], dtype=self.output_dtype),
+            )
+            response = pb_utils.InferenceResponse(
+                output_tensors=[output_tensor], error=lora_error
+            )
+            response_sender = request.get_response_sender()
+            response_sender.send(
+                response, flags=pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL
+            )
+        else:
+            verified_request = request
+        return verified_request
+
     def execute(self, requests):
         """
         Triton core issues requests to the backend via this method.
@@ -396,7 +434,9 @@ class TritonPythonModel:
         We are pushing all the requests on vllm and let it handle the full traffic.
         """
         for request in requests:
-            self.create_task(self.generate(request))
+            request = self.verify_loras(request)
+            if request is not None:
+                self.create_task(self.generate(request))
         return None
 
     def finalize(self):

--- a/src/model.py
+++ b/src/model.py
@@ -197,7 +197,7 @@ class TritonPythonModel:
             self.logger.log_info(
                 f"Detected KIND_GPU model instance, explicitly setting GPU device={triton_device_id} for {triton_instance}"
             )
-            # vLLM doesn't currently expose device selection in the APIs
+            # vLLM doesn't currently (v0.4.2) expose device selection in the APIs
             torch.cuda.set_device(triton_device_id)
 
     def create_task(self, coro):

--- a/src/model.py
+++ b/src/model.py
@@ -98,8 +98,31 @@ class TritonPythonModel:
         return auto_complete_model_config
 
     def initialize(self, args):
+        self.args = args
         self.logger = pb_utils.Logger
         self.model_config = json.loads(args["model_config"])
+        output_config = pb_utils.get_output_config_by_name(
+            self.model_config, "text_output"
+        )
+        self.output_dtype = pb_utils.triton_string_to_numpy(output_config["data_type"])
+
+        # Prepare vLLM engine
+        self.init_engine()
+
+        # Counter to keep track of ongoing request counts
+        self.ongoing_request_count = 0
+
+        # Starting asyncio event loop to process the received requests asynchronously.
+        self._loop = asyncio.get_event_loop()
+        self._loop_thread = threading.Thread(
+            target=self.engine_loop, args=(self._loop,)
+        )
+        self._shutdown_event = asyncio.Event()
+        self._loop_thread.start()
+
+    def init_engine(self):
+        # Currently, Triton needs to use decoupled policy for asynchronously
+        # forwarding requests to vLLM engine, so assert it.
 
         # assert are in decoupled mode. Currently, Triton needs to use
         # decoupled policy for asynchronously forwarding requests to
@@ -118,17 +141,25 @@ class TritonPythonModel:
             engine_args_filepath
         ), f"'{_VLLM_ENGINE_ARGS_FILENAME}' containing vllm engine args must be provided in '{pb_utils.get_model_dir()}'"
         with open(engine_args_filepath) as file:
-            vllm_engine_config = json.load(file)
+            self.vllm_engine_config = json.load(file)
+
+        # Validate device and multi-processing settings are currently set based on model/configs.
+        self.validate_device_config()
+
+        # Check for LoRA config and set it up if enabled
+        self.setup_lora()
 
         # Create an AsyncLLMEngine from the config from JSON
         self.llm_engine = AsyncLLMEngine.from_engine_args(
-            AsyncEngineArgs(**vllm_engine_config)
+            AsyncEngineArgs(**self.vllm_engine_config)
         )
+
+    def setup_lora(self):
         self.enable_lora = False
 
         if (
-            "enable_lora" in vllm_engine_config.keys()
-            and vllm_engine_config["enable_lora"].lower() == "true"
+            "enable_lora" in self.vllm_engine_config.keys()
+            and self.vllm_engine_config["enable_lora"].lower() == "true"
         ):
             # create Triton LoRA weights repository
             multi_lora_args_filepath = os.path.join(
@@ -146,21 +177,31 @@ class TritonPythonModel:
                     f"Triton backend cannot find {multi_lora_args_filepath}."
                 )
 
-        output_config = pb_utils.get_output_config_by_name(
-            self.model_config, "text_output"
-        )
-        self.output_dtype = pb_utils.triton_string_to_numpy(output_config["data_type"])
+    def validate_device_config(self):
+        triton_kind = self.args["model_instance_kind"]
+        triton_device_id = self.args["model_instance_device_id"]
+        triton_instance = f"{self.args['model_name']}_{triton_device_id}"
 
-        # Counter to keep track of ongoing request counts
-        self.ongoing_request_count = 0
+        # Triton's current definition of KIND_GPU makes assumptions that
+        # models only use a single GPU. For multi-GPU models, the recommendation
+        # is to specify KIND_MODEL to acknowledge that the model will take control
+        # of the devices made available to it.
+        # NOTE: Consider other parameters that would indicate multi-GPU in the future.
+        tp_size = int(self.vllm_engine_config.get("tensor_parallel_size", 1))
+        if tp_size > 1 and triton_kind == "GPU":
+            raise ValueError(
+                "KIND_GPU is for single-GPU models, please specify KIND_MODEL in the model's config.pbtxt for multi-GPU models"
+            )
 
-        # Starting asyncio event loop to process the received requests asynchronously.
-        self._loop = asyncio.get_event_loop()
-        self._loop_thread = threading.Thread(
-            target=self.engine_loop, args=(self._loop,)
-        )
-        self._shutdown_event = asyncio.Event()
-        self._loop_thread.start()
+        # If KIND_GPU is specified, isolate the selected GPU device to ensure that multiple model instances do not all use the same default
+        # device (usually device 0) when KIND_GPU is used.
+        if triton_kind == "GPU" and int(triton_device_id) >= 0:
+            self.logger.log_info(
+                f"Detected KIND_GPU model instance, explicitly setting GPU device={triton_device_id} for {triton_instance}"
+            )
+            # NOTE: this only affects this process and it's subprocesses, not other processes.
+            # vLLM doesn't currently seem to expose selecting a specific device in the APIs.
+            os.environ["CUDA_VISIBLE_DEVICES"] = triton_device_id
 
     def create_task(self, coro):
         """

--- a/src/model.py
+++ b/src/model.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -28,18 +28,16 @@ import asyncio
 import json
 import os
 import threading
-from typing import Dict, List
+from typing import AsyncGenerator
 
 import numpy as np
 import triton_python_backend_utils as pb_utils
+from vllm import SamplingParams
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine
-from vllm.lora.request import LoRARequest
-from vllm.sampling_params import SamplingParams
 from vllm.utils import random_uuid
 
 _VLLM_ENGINE_ARGS_FILENAME = "model.json"
-_MULTI_LORA_ARGS_FILENAME = "multi_lora.json"
 
 
 class TritonPythonModel:
@@ -98,53 +96,12 @@ class TritonPythonModel:
         return auto_complete_model_config
 
     def initialize(self, args):
+        self.args = args
         self.logger = pb_utils.Logger
         self.model_config = json.loads(args["model_config"])
 
-        # assert are in decoupled mode. Currently, Triton needs to use
-        # decoupled policy for asynchronously forwarding requests to
-        # vLLM engine.
-        self.using_decoupled = pb_utils.using_decoupled_model_transaction_policy(
-            self.model_config
-        )
-        assert (
-            self.using_decoupled
-        ), "vLLM Triton backend must be configured to use decoupled model transaction policy"
-
-        engine_args_filepath = os.path.join(
-            pb_utils.get_model_dir(), _VLLM_ENGINE_ARGS_FILENAME
-        )
-        assert os.path.isfile(
-            engine_args_filepath
-        ), f"'{_VLLM_ENGINE_ARGS_FILENAME}' containing vllm engine args must be provided in '{pb_utils.get_model_dir()}'"
-        with open(engine_args_filepath) as file:
-            vllm_engine_config = json.load(file)
-
-        # Create an AsyncLLMEngine from the config from JSON
-        self.llm_engine = AsyncLLMEngine.from_engine_args(
-            AsyncEngineArgs(**vllm_engine_config)
-        )
-        self.enable_lora = False
-
-        if (
-            "enable_lora" in vllm_engine_config.keys()
-            and vllm_engine_config["enable_lora"].lower() == "true"
-        ):
-            # create Triton LoRA weights repository
-            multi_lora_args_filepath = os.path.join(
-                pb_utils.get_model_dir(), _MULTI_LORA_ARGS_FILENAME
-            )
-            try:
-                with open(multi_lora_args_filepath) as lora_file:
-                    lora_repository: Dict[str, str] = json.load(lora_file)
-                self.lora_repository = lora_repository
-                self.supported_loras: List[str] = list(self.lora_repository.keys())
-                self.supported_loras_len = len(self.supported_loras)
-                self.enable_lora = True
-            except FileNotFoundError:
-                raise FileNotFoundError(
-                    f"Triton backend cannot find {multi_lora_args_filepath}."
-                )
+        # Prepare vLLM engine
+        self.init_engine()
 
         output_config = pb_utils.get_output_config_by_name(
             self.model_config, "text_output"
@@ -161,6 +118,59 @@ class TritonPythonModel:
         )
         self._shutdown_event = asyncio.Event()
         self._loop_thread.start()
+
+    def init_engine(self):
+        # Currently, Triton needs to use decoupled policy for asynchronously
+        # forwarding requests to vLLM engine, so assert it.
+        self.using_decoupled = pb_utils.using_decoupled_model_transaction_policy(
+            self.model_config
+        )
+        assert (
+            self.using_decoupled
+        ), "vLLM Triton backend must be configured to use decoupled model transaction policy"
+
+        # Parse user-provided vLLM config
+        engine_args_filepath = os.path.join(
+            pb_utils.get_model_dir(), _VLLM_ENGINE_ARGS_FILENAME
+        )
+        assert os.path.isfile(
+            engine_args_filepath
+        ), f"'{_VLLM_ENGINE_ARGS_FILENAME}' containing vllm engine args must be provided in '{pb_utils.get_model_dir()}'"
+
+        with open(engine_args_filepath) as file:
+            vllm_engine_config = json.load(file)
+
+        # Validate device and multi-processing settings are currently set based on model/configs.
+        kind = self.args["model_instance_kind"]
+        device_id = self.args["model_instance_device_id"]
+        self.validate_device_config(kind, device_id, vllm_engine_config)
+
+        # Create an AsyncLLMEngine from the config from JSON
+        self.llm_engine = AsyncLLMEngine.from_engine_args(
+            AsyncEngineArgs(**vllm_engine_config)
+        )
+
+    def validate_device_config(self, triton_kind, triton_device_id, vllm_engine_config):
+        # Triton's current definition of KIND_GPU makes assumptions that
+        # models only use a single GPU. For multi-GPU models, the recommendation
+        # is to specify KIND_MODEL to acknowledge that the model will take control
+        # of the devices made available to it.
+        # NOTE: Consider other parameters that would indicate multi-GPU in the future.
+        tp_size = int(vllm_engine_config.get("tensor_parallel_size", 1))
+        if tp_size > 1 and triton_kind == "GPU":
+            raise ValueError(
+                "KIND_GPU is for single-GPU models, please specify KIND_MODEL in the model's config.pbtxt for multi-GPU models"
+            )
+
+        # If KIND_GPU is specified, isolate the selected GPU device to ensure that multiple model instances do not all use the same default
+        # device (usually device 0) when KIND_GPU is used.
+        if triton_kind == "GPU" and int(triton_device_id) >= 0:
+            self.logger.log_info(
+                f"Detected KIND_GPU model instance, explicitly setting GPU device={device_id}"
+            )
+            # NOTE: this only affects this process and it's subprocesses, not other processes.
+            # vLLM doesn't currently seem to expose selecting a specific device in the APIs.
+            os.environ["CUDA_VISIBLE_DEVICES"] = triton_device_id
 
     def create_task(self, coro):
         """
@@ -319,19 +329,12 @@ class TritonPythonModel:
                 parameters = request.parameters()
 
             sampling_params_dict = self.get_sampling_params_dict(parameters)
-            lora_name = sampling_params_dict.pop("lora_name", None)
             sampling_params = SamplingParams(**sampling_params_dict)
+
             last_output = None
             prev_outputs = None
-            lora_request = None
-            if lora_name is not None:
-                lora_id = str(self.supported_loras.index(lora_name) + 1)
-                lora_int_id = int(lora_id)
-                lora_local_path = self.lora_repository[lora_name]
-                lora_request = LoRARequest(lora_id, lora_int_id, lora_local_path)
-
             async for output in self.llm_engine.generate(
-                prompt, sampling_params, request_id, lora_request=lora_request
+                prompt, sampling_params, request_id
             ):
                 if response_sender.is_cancelled():
                     self.logger.log_info("[vllm] Cancelling the request")
@@ -380,49 +383,6 @@ class TritonPythonModel:
         finally:
             self.ongoing_request_count -= 1
 
-    def verify_loras(self, request):
-        # We will check if the requested lora exists here, if not we will send a
-        # response with `LoRA not found` information. In this way we may avoid
-        # further processing.
-        verified_request = None
-        lora_error = None
-        lora_name = None
-        parameters_input_tensor = pb_utils.get_input_tensor_by_name(
-            request, "sampling_parameters"
-        )
-        if parameters_input_tensor:
-            parameters = parameters_input_tensor.as_numpy()[0].decode("utf-8")
-            sampling_params_dict = self.get_sampling_params_dict(parameters)
-            lora_name = sampling_params_dict.pop("lora_name", None)
-
-        if lora_name is not None:
-            if not self.enable_lora:
-                lora_error = pb_utils.TritonError("LoRA feature is not enabled.")
-                self.logger.log_info(
-                    "[vllm] LoRA is not enabled, please restart the backend with LoRA enabled."
-                )
-            elif lora_name not in self.supported_loras:
-                lora_error = pb_utils.TritonError(
-                    f"LoRA {lora_name} is not supported, we currently support {self.supported_loras}"
-                )
-                self.logger.log_info(f"[vllm] LoRA {lora_name} not found.")
-
-        if lora_error is not None:
-            output_tensor = pb_utils.Tensor(
-                "text_output",
-                np.asarray(["[Error] Unsupported LoRA."], dtype=self.output_dtype),
-            )
-            response = pb_utils.InferenceResponse(
-                output_tensors=[output_tensor], error=lora_error
-            )
-            response_sender = request.get_response_sender()
-            response_sender.send(
-                response, flags=pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL
-            )
-        else:
-            verified_request = request
-        return verified_request
-
     def execute(self, requests):
         """
         Triton core issues requests to the backend via this method.
@@ -434,9 +394,7 @@ class TritonPythonModel:
         We are pushing all the requests on vllm and let it handle the full traffic.
         """
         for request in requests:
-            request = self.verify_loras(request)
-            if request is not None:
-                self.create_task(self.generate(request))
+            self.create_task(self.generate(request))
         return None
 
     def finalize(self):

--- a/src/model.py
+++ b/src/model.py
@@ -123,10 +123,6 @@ class TritonPythonModel:
     def init_engine(self):
         # Currently, Triton needs to use decoupled policy for asynchronously
         # forwarding requests to vLLM engine, so assert it.
-
-        # assert are in decoupled mode. Currently, Triton needs to use
-        # decoupled policy for asynchronously forwarding requests to
-        # vLLM engine.
         self.using_decoupled = pb_utils.using_decoupled_model_transaction_policy(
             self.model_config
         )


### PR DESCRIPTION
#### What does the PR do?

##### Problem

When loading multiple instances of a vLLM model on a multi-gpu system (default behavior with KIND_GPU which is the default instance group when left unspecified), all model instances will default to the same device and can cause a CUDA OOM rather than loading a model on each GPU device assigned by the instance group settings.

This is rooted in Triton's KIND_GPU behavior making an assumption that the model is assigned only one GPU. In the future, KIND_GPU may be expanded to define a set of multiple GPUs for a single model. However, for now the recommendation is to use KIND_MODEL when a model can have multiple GPUs and use them freely (such as python models).

##### Solution

These changes try to account for this assumption by isolating the assigned GPU device ID when KIND_GPU is used, and otherwise raising an error and recommending usage of KIND_MODEL when the vLLM config implies that this is a multi-GPU model (such as `tensor_parallel_size > 1`).

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) box here and add the label to the github PR.
- [ ] build
- [ ] chore
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [x] test



#### Test plan

1. Single-gpu model on a multi-gpu system with KIND_GPU (default)

**Change**: Success, specify device ID assigned by Triton Core (from the instance group) when initializing vLLM to avoid OOM from all instances defaulting to device 0.

```
I0524 19:05:41.036859 3948 model.py:170] Detected KIND_GPU model instance, explicitly setting GPU device=0 for llama-3-8b-instruct_0
I0524 19:05:41.043640 3948 model.py:170] Detected KIND_GPU model instance, explicitly setting GPU device=1 for llama-3-8b-instruct_1
```

2. Multi-gpu model (tensor_parallel_size > 1) with KIND_GPU (default)

**Change**: Failure, with clear error to specify KIND_MODEL instead for multi-gpu models

![image](https://github.com/triton-inference-server/vllm_backend/assets/21284872/72eb3e32-354e-464d-be6a-05dc6bcd306e)

3. Multi-gpu model (tensor_parallel_size > 1) with KIND_MODEL (manually specified)

Success, and auto uses Ray Worker.

![image](https://github.com/triton-inference-server/vllm_backend/assets/21284872/acd79afb-283c-4dc4-8b86-0bba7db4fc80)


#### Caveats

1. If there are other vLLM config fields that can imply multi-gpu other than `tensor_parallel_size`, we can add checks for those too.
2. For `KIND_MODEL` models with `tensor_parallelism == 1` and `model_instance_count > 1`, we run into the same issue where vLLM will try to allocate each instance on the same GPU. This could be enhanced with a similar check in this PR, or  deferred to future enhancement.
3. This PR doesn't provide an explicitly good way to support the case for multiple multi-gpu instances.
    - Take a 2-GPU model that you want 4 copies of on an 8-GPU system as an example.
    - If you specify KIND_MODEL in the config with 4 model instances, and `tensor_parallel_size: 2`, with 8-GPUs at your disposal, there's currently no explicit check or validation around this. I don't know how this would behave, and would likely default to how the RayWorker logic in vLLM would attempt to assign GPUs.