### PR TITLE
Removed explicit mode for multi-lora

### DIFF
--- a/ci/L0_multi_gpu/multi_lora/multi_lora_test.py
+++ b/ci/L0_multi_gpu/multi_lora/multi_lora_test.py
@@ -119,7 +119,6 @@ class VLLMTritonLoraTest(AsyncTestResultCollector):
         self.triton_client.stop_stream()
 
     def test_multi_lora_requests(self):
-        self.triton_client.load_model(self.vllm_model_name)
         sampling_parameters = {"temperature": "0", "top_p": "1"}
         # make two requests separately to avoid the different arrival of response answers
         prompt_1 = ["Instruct: What do you think of Computer Science?\nOutput:"]
@@ -151,10 +150,8 @@ class VLLMTritonLoraTest(AsyncTestResultCollector):
             exclude_input_in_output=True,
             expected_output=expected_output,
         )
-        self.triton_client.unload_model(self.vllm_model_name)
 
     def test_none_exist_lora(self):
-        self.triton_client.load_model(self.vllm_model_name)
         prompts = [
             "Instruct: What is the capital city of France?\nOutput:",
         ]
@@ -169,7 +166,6 @@ class VLLMTritonLoraTest(AsyncTestResultCollector):
             exclude_input_in_output=True,
             expected_output=None,  # this request will lead to lora not supported error, so there is no expected output
         )
-        self.triton_client.unload_model(self.vllm_model_name)
 
     def tearDown(self):
         self.triton_client.close()

--- a/ci/L0_multi_gpu/multi_lora/test.sh
+++ b/ci/L0_multi_gpu/multi_lora/test.sh
@@ -30,7 +30,7 @@ source ../../common/util.sh
 TRITON_DIR=${TRITON_DIR:="/opt/tritonserver"}
 SERVER=${TRITON_DIR}/bin/tritonserver
 BACKEND_DIR=${TRITON_DIR}/backends
-SERVER_ARGS="--model-repository=`pwd`/models --backend-directory=${BACKEND_DIR} --model-control-mode=explicit --log-verbose=1"
+SERVER_ARGS="--model-repository=`pwd`/models --backend-directory=${BACKEND_DIR} --log-verbose=1"
 SERVER_LOG="./multi_lora_server.log"
 CLIENT_LOG="./multi_lora_client.log"
 TEST_RESULT_FILE='test_results.txt'


### PR DESCRIPTION
explicit model load was causing failures in tests with vllm==v0.5.0.post1
