### PR TITLE
test: Limiting multi-gpu tests to use Ray as distributed_executor_backend 

### DIFF
--- a/ci/L0_multi_gpu/multi_lora/test.sh
+++ b/ci/L0_multi_gpu/multi_lora/test.sh
@@ -62,7 +62,8 @@ model_json=$(cat <<EOF
     "enforce_eager": "true",
     "enable_lora": "true",
     "max_lora_rank": 32,
-    "lora_extra_vocab_size": 256
+    "lora_extra_vocab_size": 256,
+    "distributed_executor_backend":"ray"
 }
 EOF
 )
@@ -120,7 +121,8 @@ model_json=$(cat <<EOF
     "block_size": 16,
     "enforce_eager": "true",
     "enable_lora": "false",
-    "lora_extra_vocab_size": 256
+    "lora_extra_vocab_size": 256,
+    "distributed_executor_backend":"ray"
 }
 EOF
 )

--- a/ci/L0_multi_gpu/vllm_backend/test.sh
+++ b/ci/L0_multi_gpu/vllm_backend/test.sh
@@ -30,7 +30,7 @@ source ../../common/util.sh
 TRITON_DIR=${TRITON_DIR:="/opt/tritonserver"}
 SERVER=${TRITON_DIR}/bin/tritonserver
 BACKEND_DIR=${TRITON_DIR}/backends
-SERVER_ARGS="--model-repository=`pwd`/models --backend-directory=${BACKEND_DIR} --model-control-mode=explicit --log-verbose=1"
+SERVER_ARGS="--model-repository=`pwd`/models --backend-directory=${BACKEND_DIR} --log-verbose=1"
 TEST_RESULT_FILE='test_results.txt'
 CLIENT_PY="./vllm_multi_gpu_test.py"
 SAMPLE_MODELS_REPO="../../../samples/model_repository"
@@ -107,11 +107,6 @@ function run_multi_gpu_test() {
 
     # Cleanup
     kill $SERVER_PID
-    sleep 10
-    echo -e "\n***\n*** DEBUG SERVER LOG.\n***"
-    cat $SERVER_LOG
-    echo -e "\n***\n*** DEBUG CLIENT LOG.\n***"
-    cat $CLIENT_LOG
     wait $SERVER_PID
 }
 

--- a/ci/L0_multi_gpu/vllm_backend/test.sh
+++ b/ci/L0_multi_gpu/vllm_backend/test.sh
@@ -116,7 +116,7 @@ RET=0
 
 # Test the various cases of kind, tensor parallelism, and instance count
 # for different ways to run multi-GPU models with vLLM on Triton
-KINDS="KIND_MODEL KIND_GPU"
+KINDS="KIND_GPU"
 TPS="1 2"
 INSTANCE_COUNTS="1 2"
 for kind in ${KINDS}; do

--- a/ci/L0_multi_gpu/vllm_backend/test.sh
+++ b/ci/L0_multi_gpu/vllm_backend/test.sh
@@ -35,6 +35,8 @@ TEST_RESULT_FILE='test_results.txt'
 CLIENT_PY="./vllm_multi_gpu_test.py"
 SAMPLE_MODELS_REPO="../../../samples/model_repository"
 EXPECTED_NUM_TESTS=1
+export VLLM_ATTENTION_BACKEND=XFORMERS
+export CUDA_VISIBLE_DEVICES="0,1"
 
 ### Helpers
 function validate_file_contains() {

--- a/ci/L0_multi_gpu/vllm_backend/test.sh
+++ b/ci/L0_multi_gpu/vllm_backend/test.sh
@@ -123,7 +123,7 @@ RET=0
 
 # Test the various cases of kind, tensor parallelism, and instance count
 # for different ways to run multi-GPU models with vLLM on Triton
-KINDS="KIND_GPU"
+KINDS="KIND_MODEL KIND_GPU"
 TPS="1 2"
 INSTANCE_COUNTS="1 2"
 DISTRIBUTED_EXECUTOR_BACKEND="ray"

--- a/ci/L0_multi_gpu/vllm_backend/test.sh
+++ b/ci/L0_multi_gpu/vllm_backend/test.sh
@@ -35,8 +35,6 @@ TEST_RESULT_FILE='test_results.txt'
 CLIENT_PY="./vllm_multi_gpu_test.py"
 SAMPLE_MODELS_REPO="../../../samples/model_repository"
 EXPECTED_NUM_TESTS=1
-export VLLM_ATTENTION_BACKEND=XFORMERS
-export CUDA_VISIBLE_DEVICES="0,1"
 
 ### Helpers
 function validate_file_contains() {

--- a/ci/L0_multi_gpu/vllm_backend/test.sh
+++ b/ci/L0_multi_gpu/vllm_backend/test.sh
@@ -105,13 +105,13 @@ function run_multi_gpu_test() {
     fi
     set -e
 
+    # Cleanup
+    kill $SERVER_PID
+    sleep 10
     echo -e "\n***\n*** DEBUG SERVER LOG.\n***"
     cat $SERVER_LOG
     echo -e "\n***\n*** DEBUG CLIENT LOG.\n***"
     cat $CLIENT_LOG
-
-    # Cleanup
-    kill $SERVER_PID
     wait $SERVER_PID
 }
 

--- a/ci/L0_multi_gpu/vllm_backend/test.sh
+++ b/ci/L0_multi_gpu/vllm_backend/test.sh
@@ -105,6 +105,11 @@ function run_multi_gpu_test() {
     fi
     set -e
 
+    echo -e "\n***\n*** DEBUG SERVER LOG.\n***"
+    cat $SERVER_LOG
+    echo -e "\n***\n*** DEBUG CLIENT LOG.\n***"
+    cat $CLIENT_LOG
+
     # Cleanup
     kill $SERVER_PID
     wait $SERVER_PID

--- a/ci/L0_multi_gpu/vllm_backend/test.sh
+++ b/ci/L0_multi_gpu/vllm_backend/test.sh
@@ -30,7 +30,7 @@ source ../../common/util.sh
 TRITON_DIR=${TRITON_DIR:="/opt/tritonserver"}
 SERVER=${TRITON_DIR}/bin/tritonserver
 BACKEND_DIR=${TRITON_DIR}/backends
-SERVER_ARGS="--model-repository=`pwd`/models --backend-directory=${BACKEND_DIR} --log-verbose=1"
+SERVER_ARGS="--model-repository=`pwd`/models --backend-directory=${BACKEND_DIR} --model-control-mode=explicit --log-verbose=1"
 TEST_RESULT_FILE='test_results.txt'
 CLIENT_PY="./vllm_multi_gpu_test.py"
 SAMPLE_MODELS_REPO="../../../samples/model_repository"

--- a/ci/L0_multi_gpu/vllm_backend/test.sh
+++ b/ci/L0_multi_gpu/vllm_backend/test.sh
@@ -65,6 +65,7 @@ function run_multi_gpu_test() {
     export KIND="${1}"
     export TENSOR_PARALLELISM="${2}"
     export INSTANCE_COUNT="${3}"
+    export DISTRIBUTED_EXECUTOR_BACKEND="${4}"
 
     # Setup a clean model repository
     export TEST_MODEL="vllm_opt_${KIND}_tp${TENSOR_PARALLELISM}_count${INSTANCE_COUNT}"
@@ -75,6 +76,10 @@ function run_multi_gpu_test() {
     cp -r "${SAMPLE_MODELS_REPO}/vllm_model" "models/${TEST_MODEL}"
     sed -i "s/KIND_MODEL/${KIND}/" "${TEST_MODEL_TRITON_CONFIG}"
     sed -i "3s/^/    \"tensor_parallel_size\": ${TENSOR_PARALLELISM},\n/" "${TEST_MODEL_VLLM_CONFIG}"
+    if [ $TENSOR_PARALLELISM -ne "1" ]; then
+        jq --arg backend $DISTRIBUTED_EXECUTOR_BACKEND '. += {"distributed_executor_backend":$backend}' "${TEST_MODEL_VLLM_CONFIG}" > "temp.json"
+        mv temp.json "${TEST_MODEL_VLLM_CONFIG}"
+    fi
     # Assert the correct kind is set in case the template config changes in the future
     validate_file_contains "${KIND}" "${TEST_MODEL_TRITON_CONFIG}"
 
@@ -121,10 +126,11 @@ RET=0
 KINDS="KIND_GPU"
 TPS="1 2"
 INSTANCE_COUNTS="1 2"
+DISTRIBUTED_EXECUTOR_BACKEND="ray"
 for kind in ${KINDS}; do
   for tp in ${TPS}; do
     for count in ${INSTANCE_COUNTS}; do
-        run_multi_gpu_test "${kind}" "${tp}" "${count}"
+        run_multi_gpu_test "${kind}" "${tp}" "${count}" "${DISTRIBUTED_EXECUTOR_BACKEND}"
     done
   done
 done

--- a/samples/model_repository/vllm_model/1/model.json
+++ b/samples/model_repository/vllm_model/1/model.json
@@ -2,5 +2,6 @@
     "model":"facebook/opt-125m",
     "disable_log_requests": "true",
     "gpu_memory_utilization": 0.5,
-    "enforce_eager": "true"
+    "enforce_eager": "true",
+    "distributed_executor_backend":"ray"
 }

--- a/samples/model_repository/vllm_model/1/model.json
+++ b/samples/model_repository/vllm_model/1/model.json
@@ -2,6 +2,5 @@
     "model":"facebook/opt-125m",
     "disable_log_requests": "true",
     "gpu_memory_utilization": 0.5,
-    "enforce_eager": "true",
-    "distributed_executor_backend":"ray"
+    "enforce_eager": "true"
 }


### PR DESCRIPTION
In PR [#5230](https://github.com/vllm-project/vllm/pull/5230) vllm changed default executor for distributed serving from Ray to `python native multiprocessing` for single node processing. This becomes in issue to Triton starting with v0.5.1 release.
For `python native multiprocessing` mode and KIND_MODEL setting, Triton hits "failed to stop server: Internal - Exit timeout expired. Exiting immediately." and `pt_main_thread` processes are never stopped/killed. I'll create an issue a bit later.

Solution: support only Ray for deploying models with tensor_parallel_size > 1 via "distributed_executor_backend" flag until the issue is fixed. 

This PR adjusts our multi-gpu tests according to the above observations