### PR TITLE
perf: Check for cancellation on response thread

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -424,7 +424,7 @@ class TritonPythonModel:
                         response_state["last_response_generated"] = True
                         response = pb_utils.InferenceResponse(
                             error=pb_utils.TritonError(
-                                message="cancelled on the client side",
+                                message="Request was cancelled",
                                 code=pb_utils.TritonError.CANCELLED,
                             )
                         )

--- a/src/model.py
+++ b/src/model.py
@@ -289,14 +289,12 @@ class TritonPythonModel:
                 break
             response_state, response, response_flag = item
             del item
-            response_sender, number_response_sent = response_state[0], response_state[3]
+            response_sender = response_state[0]
             try:
                 response_sender.send(response, response_flag)
-                response_state[3] = number_response_sent + 1
-                # Check for cancellation only if the last response is not yet generated
-                # and for every 10 response.
                 last_response_ready = response_state[2]
-                if not last_response_ready and number_response_sent % 2 == 0:
+                # Stop checking for cancellation if the last response is generated.
+                if not last_response_ready:
                     is_cancelled = response_sender.is_cancelled()
                     response_state[1] = is_cancelled
             except Exception as e:
@@ -355,7 +353,6 @@ class TritonPythonModel:
             response_sender,
             False,  # is cancelled
             False,  # last response ready to be sent
-            0,  # number of response sent
         ]
         self.ongoing_request_count += 1
         decrement_ongoing_request_count = True

--- a/src/model.py
+++ b/src/model.py
@@ -289,12 +289,14 @@ class TritonPythonModel:
                 break
             response_state, response, response_flag = item
             del item
-            response_sender = response_state[0]
+            response_sender, number_response_sent = response_state[0], response_state[3]
             try:
                 response_sender.send(response, response_flag)
+                response_state[3] = number_response_sent + 1
+                # Check for cancellation only if the last response is not yet generated
+                # and for every 10 response.
                 last_response_ready = response_state[2]
-                # Stop checking for cancellation if the last response is generated.
-                if not last_response_ready:
+                if not last_response_ready and number_response_sent % 2 == 0:
                     is_cancelled = response_sender.is_cancelled()
                     response_state[1] = is_cancelled
             except Exception as e:
@@ -353,6 +355,7 @@ class TritonPythonModel:
             response_sender,
             False,  # is cancelled
             False,  # last response ready to be sent
+            0,  # number of response sent
         ]
         self.ongoing_request_count += 1
         decrement_ongoing_request_count = True

--- a/src/model.py
+++ b/src/model.py
@@ -424,7 +424,7 @@ class TritonPythonModel:
                         response_state["last_response_generated"] = True
                         response = pb_utils.InferenceResponse(
                             error=pb_utils.TritonError(
-                                message="user cancelled",
+                                message="cancelled on the client side",
                                 code=pb_utils.TritonError.CANCELLED,
                             )
                         )


### PR DESCRIPTION
#### What does the PR do?
<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
Cancellation check is to be performed during the response loop on the response thread. The status of the cancellation will be written back a object shared between the response loop and generate loop on a particular request. After sending a response, the cancellation status will be checked and the generate loop will cancel the generation if the request is cancelled. Combined with the release of GIL while checking for cancellation, this maximizes the vLLM generation time on the GIL, which has seen noticeable performance improvement.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [x] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
<!-- Related PRs from other Repositories -->
https://github.com/triton-inference-server/python_backend/pull/372

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->
Start at once a cancellation is issued while responses are being actively generated, does the generate loop capture the cancellation signal? Is the final flag sent (both streaming/non-streaming) after cancelling? Is the response sender deleted and garbage collected after cancelling?

#### Test plan:
<!-- list steps to verify -->
<!-- were e2e tests added?-->
This is a performance improvement, so any issue should be covered by existing test cases.

- CI Pipeline ID: 17061062
<!-- Only Pipeline ID and no direct link here -->

#### Caveats:
<!-- any limitations or possible things missing from this PR -->
N/A

#### Background
<!-- e.g. what led to this change being made. this is optional extra information to help the reviewer -->
Need to improve the performance on vLLM backend.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
N/A