### PR TITLE
refactor: Remove explicit callings to garbage collect

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -520,3 +520,9 @@ class TritonPythonModel:
         if self._response_thread is not None:
             self._response_thread.join()
             self._response_thread = None
+
+        # When using parallel tensors, the stub process may not shutdown due to
+        # uncollected garbage, so manually run the garbage collector once.
+        self.logger.log_info("[vllm] Collecting garbage on finalize...")
+        gc.collect()
+        self.logger.log_info("[vllm] Collecting garbage on finalize... done")

--- a/src/model.py
+++ b/src/model.py
@@ -522,7 +522,7 @@ class TritonPythonModel:
             self._response_thread = None
 
         # When using parallel tensors, the stub process may not shutdown due to
-        # uncollected garbage, so manually run the garbage collector once.
-        self.logger.log_info("[vllm] Collecting garbage on finalize...")
+        # unreleased references, so manually run the garbage collector once.
+        self.logger.log_info("[vllm] Running Garbage Collector on finalize...")
         gc.collect()
-        self.logger.log_info("[vllm] Collecting garbage on finalize... done")
+        self.logger.log_info("[vllm] Garbage Collector on finalize... done")

--- a/src/model.py
+++ b/src/model.py
@@ -288,7 +288,6 @@ class TritonPythonModel:
             if item is None:
                 break
             response_sender, response, response_flag = item
-            del item
             try:
                 response_sender.send(response, response_flag)
             except Exception as e:
@@ -298,9 +297,6 @@ class TritonPythonModel:
             finally:
                 if response_flag == pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL:
                     self.ongoing_request_count -= 1
-                    del response_sender
-                    if self.ongoing_request_count == 0:
-                        gc.collect()
 
     def create_response(self, vllm_output, prepend_input):
         """
@@ -447,9 +443,6 @@ class TritonPythonModel:
         finally:
             if decrement_ongoing_request_count:
                 self.ongoing_request_count -= 1
-                del response_sender
-                if self.ongoing_request_count == 0:
-                    gc.collect()
 
     def verify_loras(self, request):
         # We will check if the requested lora exists here, if not we will send a


### PR DESCRIPTION
#### What does the PR do?
<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
Remove the explicit calling to garbage collector. The lifecycle of response_sender and response_factory are expected to be handled by the Python backend internally.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [x] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
<!-- Related PRs from other Repositories -->
https://github.com/triton-inference-server/server/pull/7504
https://github.com/triton-inference-server/python_backend/pull/373

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->
N/A

#### Test plan:
<!-- list steps to verify -->
<!-- were e2e tests added?-->
The PR refactors how the response_sender object lifecycle is handled, it is neither a feature nor a bug fix, so existing tests should be sufficient to cover any regression.

- CI Pipeline ID: 17156719
<!-- Only Pipeline ID and no direct link here -->

#### Caveats:
<!-- any limitations or possible things missing from this PR -->
When parallel tensors > 1, the stub process can fail to unload (with finalize() called and returned successfully), so it is necessary to manually call garbage collect once at the end of finalize().

#### Background
<!-- e.g. what led to this change being made. this is optional extra information to help the reviewer -->
N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
N/A