### PR TITLE
feat: Report histogram metrics to Triton metrics server

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,45 @@ vllm:prompt_tokens_total{model="vllm_model",version="1"} 10
 # HELP vllm:generation_tokens_total Number of generation tokens processed.
 # TYPE vllm:generation_tokens_total counter
 vllm:generation_tokens_total{model="vllm_model",version="1"} 16
+# HELP vllm:time_to_first_token_seconds Histogram of time to first token in seconds.
+# TYPE vllm:time_to_first_token_seconds histogram
+vllm:time_to_first_token_seconds_count{model="vllm_model",version="1"} 1
+vllm:time_to_first_token_seconds_sum{model="vllm_model",version="1"} 0.03233122825622559
+vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.001"} 0
+vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.005"} 0
+vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.01"} 0
+vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.02"} 0
+vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.04"} 1
+vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.06"} 1
+vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.08"} 1
+vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.1"} 1
+vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.25"} 1
+vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.5"} 1
+vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.75"} 1
+vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="1"} 1
+vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="2.5"} 1
+vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="5"} 1
+vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="7.5"} 1
+vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="10"} 1
+vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="+Inf"} 1
+# HELP vllm:time_per_output_token_seconds Histogram of time per output token in seconds.
+# TYPE vllm:time_per_output_token_seconds histogram
+vllm:time_per_output_token_seconds_count{model="vllm_model",version="1"} 15
+vllm:time_per_output_token_seconds_sum{model="vllm_model",version="1"} 0.04501533508300781
+vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.01"} 14
+vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.025"} 15
+vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.05"} 15
+vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.075"} 15
+vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.1"} 15
+vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.15"} 15
+vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.2"} 15
+vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.3"} 15
+vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.4"} 15
+vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.5"} 15
+vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.75"} 15
+vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="1"} 15
+vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="2.5"} 15
+vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="+Inf"} 15
 ```
 To enable vLLM engine colleting metrics, "disable_log_stats" option need to be either false
 or left empty (false by default) in [model.json](https://github.com/triton-inference-server/vllm_backend/blob/main/samples/model_repository/vllm_model/1/model.json).

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ you need to specify a different `shm-region-prefix-name` for each server. See
 for more information.
 
 ## Triton Metrics
-Starting with the 24.08 release of Triton, users can now obtain partial
+Starting with the 24.08 release of Triton, users can now obtain specific
 vLLM metrics by querying the Triton metrics endpoint (see complete vLLM metrics
 [here](https://docs.vllm.ai/en/latest/serving/metrics.html)). This can be
 accomplished by launching a Triton server in any of the ways described above
@@ -213,9 +213,19 @@ the following:
 ```bash
 curl localhost:8002/metrics
 ```
-VLLM stats are reported by the metrics endpoint in fields that
-are prefixed with `vllm:`. Your output for these fields should look
-similar to the following:
+VLLM stats are reported by the metrics endpoint in fields that are prefixed with
+`vllm:`. Triton currently supports reporting of the following metrics from vLLM.
+```bash
+# Number of prefill tokens processed.
+counter_prompt_tokens
+# Number of generation tokens processed.
+counter_generation_tokens
+# Histogram of time to first token in seconds.
+histogram_time_to_first_token
+# Histogram of time per output token in seconds.
+histogram_time_per_output_token
+```
+Your output for these fields should look similar to the following:
 ```bash
 # HELP vllm:prompt_tokens_total Number of prefill tokens processed.
 # TYPE vllm:prompt_tokens_total counter
@@ -229,20 +239,7 @@ vllm:time_to_first_token_seconds_count{model="vllm_model",version="1"} 1
 vllm:time_to_first_token_seconds_sum{model="vllm_model",version="1"} 0.03233122825622559
 vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.001"} 0
 vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.005"} 0
-vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.01"} 0
-vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.02"} 0
-vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.04"} 1
-vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.06"} 1
-vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.08"} 1
-vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.1"} 1
-vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.25"} 1
-vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.5"} 1
-vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="0.75"} 1
-vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="1"} 1
-vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="2.5"} 1
-vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="5"} 1
-vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="7.5"} 1
-vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="10"} 1
+...
 vllm:time_to_first_token_seconds_bucket{model="vllm_model",version="1",le="+Inf"} 1
 # HELP vllm:time_per_output_token_seconds Histogram of time per output token in seconds.
 # TYPE vllm:time_per_output_token_seconds histogram
@@ -250,17 +247,7 @@ vllm:time_per_output_token_seconds_count{model="vllm_model",version="1"} 15
 vllm:time_per_output_token_seconds_sum{model="vllm_model",version="1"} 0.04501533508300781
 vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.01"} 14
 vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.025"} 15
-vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.05"} 15
-vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.075"} 15
-vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.1"} 15
-vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.15"} 15
-vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.2"} 15
-vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.3"} 15
-vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.4"} 15
-vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.5"} 15
-vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="0.75"} 15
-vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="1"} 15
-vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="2.5"} 15
+...
 vllm:time_per_output_token_seconds_bucket{model="vllm_model",version="1",le="+Inf"} 15
 ```
 To enable vLLM engine colleting metrics, "disable_log_stats" option need to be either false

--- a/ci/L0_backend_vllm/metrics_test/vllm_metrics_test.py
+++ b/ci/L0_backend_vllm/metrics_test/vllm_metrics_test.py
@@ -127,13 +127,11 @@ class VLLMTritonMetricsTest(TestResultCollector):
 
         # vllm:time_to_first_token_seconds
         self.assertEqual(metrics_dict["vllm:time_to_first_token_seconds_count"], 3)
-        self.assertTrue(0 < metrics_dict["vllm:time_to_first_token_seconds_sum"] < 0.01)
+        self.assertTrue(metrics_dict["vllm:time_to_first_token_seconds_sum"] > 0)
         self.assertEqual(metrics_dict["vllm:time_to_first_token_seconds_bucket"], 3)
         # vllm:time_per_output_token_seconds
         self.assertEqual(metrics_dict["vllm:time_per_output_token_seconds_count"], 45)
-        self.assertTrue(
-            0 < metrics_dict["vllm:time_per_output_token_seconds_sum"] < 0.1
-        )
+        self.assertTrue(metrics_dict["vllm:time_per_output_token_seconds_sum"] > 0)
         self.assertEqual(metrics_dict["vllm:time_per_output_token_seconds_bucket"], 45)
 
     def test_vllm_metrics_disabled(self):

--- a/ci/L0_backend_vllm/metrics_test/vllm_metrics_test.py
+++ b/ci/L0_backend_vllm/metrics_test/vllm_metrics_test.py
@@ -125,6 +125,17 @@ class VLLMTritonMetricsTest(TestResultCollector):
         # vllm:generation_tokens_total
         self.assertEqual(metrics_dict["vllm:generation_tokens_total"], 48)
 
+        # vllm:time_to_first_token_seconds
+        self.assertEqual(metrics_dict["vllm:time_to_first_token_seconds_count"], 3)
+        self.assertTrue(
+            0 < metrics_dict["vllm:time_to_first_token_seconds_sum"] < 0.0005
+        )
+        # vllm:time_per_output_token_seconds
+        self.assertEqual(metrics_dict["vllm:time_per_output_token_seconds_count"], 45)
+        self.assertTrue(
+            0 <= metrics_dict["vllm:time_per_output_token_seconds_sum"] <= 0.005
+        )
+
     def test_vllm_metrics_disabled(self):
         # Test vLLM metrics
         self.vllm_infer(

--- a/ci/L0_backend_vllm/metrics_test/vllm_metrics_test.py
+++ b/ci/L0_backend_vllm/metrics_test/vllm_metrics_test.py
@@ -127,14 +127,14 @@ class VLLMTritonMetricsTest(TestResultCollector):
 
         # vllm:time_to_first_token_seconds
         self.assertEqual(metrics_dict["vllm:time_to_first_token_seconds_count"], 3)
-        self.assertTrue(
-            0 < metrics_dict["vllm:time_to_first_token_seconds_sum"] < 0.0005
-        )
+        self.assertTrue(0 < metrics_dict["vllm:time_to_first_token_seconds_sum"] < 0.01)
+        self.assertEqual(metrics_dict["vllm:time_to_first_token_seconds_bucket"], 3)
         # vllm:time_per_output_token_seconds
         self.assertEqual(metrics_dict["vllm:time_per_output_token_seconds_count"], 45)
         self.assertTrue(
-            0 <= metrics_dict["vllm:time_per_output_token_seconds_sum"] <= 0.005
+            0 < metrics_dict["vllm:time_per_output_token_seconds_sum"] < 0.1
         )
+        self.assertEqual(metrics_dict["vllm:time_per_output_token_seconds_bucket"], 45)
 
     def test_vllm_metrics_disabled(self):
         # Test vLLM metrics

--- a/src/utils/metrics.py
+++ b/src/utils/metrics.py
@@ -65,6 +65,8 @@ class TritonMetrics:
         self.counter_generation_tokens = self.counter_generation_tokens_family.Metric(
             labels=labels
         )
+        # Use the same bucket boundaries from vLLM sample metrics.
+        # https://github.com/vllm-project/vllm/blob/21313e09e3f9448817016290da20d0db1adf3664/vllm/engine/metrics.py#L81-L96
         self.histogram_time_to_first_token = (
             self.histogram_time_to_first_token_family.Metric(
                 labels=labels,


### PR DESCRIPTION
Sample histogram output
```
# HELP vllm:time_to_first_token_seconds Histogram of time to first token in seconds.
# TYPE vllm:time_to_first_token_seconds histogram
vllm:time_to_first_token_seconds_count{model="vllm_opt",version="1"} 3
vllm:time_to_first_token_seconds_sum{model="vllm_opt",version="1"} 0.0002238750457763672
vllm:time_to_first_token_seconds_bucket{model="vllm_opt",version="1",le="0.001"} 3
vllm:time_to_first_token_seconds_bucket{model="vllm_opt",version="1",le="0.005"} 3
vllm:time_to_first_token_seconds_bucket{model="vllm_opt",version="1",le="0.01"} 3
vllm:time_to_first_token_seconds_bucket{model="vllm_opt",version="1",le="0.02"} 3
vllm:time_to_first_token_seconds_bucket{model="vllm_opt",version="1",le="0.04"} 3
vllm:time_to_first_token_seconds_bucket{model="vllm_opt",version="1",le="0.06"} 3
vllm:time_to_first_token_seconds_bucket{model="vllm_opt",version="1",le="0.08"} 3
vllm:time_to_first_token_seconds_bucket{model="vllm_opt",version="1",le="0.1"} 3
vllm:time_to_first_token_seconds_bucket{model="vllm_opt",version="1",le="0.25"} 3
vllm:time_to_first_token_seconds_bucket{model="vllm_opt",version="1",le="0.5"} 3
vllm:time_to_first_token_seconds_bucket{model="vllm_opt",version="1",le="0.75"} 3
vllm:time_to_first_token_seconds_bucket{model="vllm_opt",version="1",le="1"} 3
vllm:time_to_first_token_seconds_bucket{model="vllm_opt",version="1",le="2.5"} 3
vllm:time_to_first_token_seconds_bucket{model="vllm_opt",version="1",le="5"} 3
vllm:time_to_first_token_seconds_bucket{model="vllm_opt",version="1",le="7.5"} 3
vllm:time_to_first_token_seconds_bucket{model="vllm_opt",version="1",le="10"} 3
vllm:time_to_first_token_seconds_bucket{model="vllm_opt",version="1",le="+Inf"} 3
# HELP vllm:time_per_output_token_seconds Histogram of time per output token in seconds.
# TYPE vllm:time_per_output_token_seconds histogram
vllm:time_per_output_token_seconds_count{model="vllm_opt",version="1"} 45
vllm:time_per_output_token_seconds_sum{model="vllm_opt",version="1"} 0.002027750015258789
vllm:time_per_output_token_seconds_bucket{model="vllm_opt",version="1",le="0.01"} 45
vllm:time_per_output_token_seconds_bucket{model="vllm_opt",version="1",le="0.025"} 45
vllm:time_per_output_token_seconds_bucket{model="vllm_opt",version="1",le="0.05"} 45
vllm:time_per_output_token_seconds_bucket{model="vllm_opt",version="1",le="0.075"} 45
vllm:time_per_output_token_seconds_bucket{model="vllm_opt",version="1",le="0.1"} 45
vllm:time_per_output_token_seconds_bucket{model="vllm_opt",version="1",le="0.15"} 45
vllm:time_per_output_token_seconds_bucket{model="vllm_opt",version="1",le="0.2"} 45
vllm:time_per_output_token_seconds_bucket{model="vllm_opt",version="1",le="0.3"} 45
vllm:time_per_output_token_seconds_bucket{model="vllm_opt",version="1",le="0.4"} 45
vllm:time_per_output_token_seconds_bucket{model="vllm_opt",version="1",le="0.5"} 45
vllm:time_per_output_token_seconds_bucket{model="vllm_opt",version="1",le="0.75"} 45
vllm:time_per_output_token_seconds_bucket{model="vllm_opt",version="1",le="1"} 45
vllm:time_per_output_token_seconds_bucket{model="vllm_opt",version="1",le="2.5"} 45
vllm:time_per_output_token_seconds_bucket{model="vllm_opt",version="1",le="+Inf"} 45
```

#### What does the PR do?
Support histogram metric type and add tests.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [x] feat

#### Related PRs:
https://github.com/triton-inference-server/python_backend/pull/374
https://github.com/triton-inference-server/core/pull/386
https://github.com/triton-inference-server/server/pull/7525

#### Where should the reviewer start?
n/a

#### Test plan:
n/a

- CI Pipeline ID:
17487728

#### Caveats:
n/a

#### Background
Customer requested histogram metrics from vLLM.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
n/a