### PR TITLE
fix: Remove unnecessary pip upgrades in testing

### DIFF
--- a/ci/L0_backend_vllm/enabled_stream/enabled_stream_test.py
+++ b/ci/L0_backend_vllm/enabled_stream/enabled_stream_test.py
@@ -72,7 +72,7 @@ class VLLMTritonStreamTest(AsyncTestResultCollector):
                 result, error = response
                 if expect_error:
                     self.assertIsInstance(error, InferenceServerException)
-                    self.assertEquals(
+                    self.assertEqual(
                         error.message(),
                         "Error generating stream: When streaming, `exclude_input_in_output` = False is not allowed.",
                         error,

--- a/ci/L0_backend_vllm/test.sh
+++ b/ci/L0_backend_vllm/test.sh
@@ -28,7 +28,7 @@
 RET=0
 SUBTESTS="accuracy_test request_cancellation enabled_stream vllm_backend metrics_test"
 
-python3 -m pip install --upgrade pip && pip3 install tritonclient[grpc]
+python3 -m pip install tritonclient[grpc]
 
 for TEST in ${SUBTESTS}; do
     (cd ${TEST} && bash -ex test.sh && cd ..)

--- a/ci/L0_multi_gpu/test.sh
+++ b/ci/L0_multi_gpu/test.sh
@@ -28,7 +28,7 @@
 RET=0
 SUBTESTS="vllm_backend multi_lora"
 
-python3 -m pip install --upgrade pip && pip3 install tritonclient[grpc]
+python3 -m pip install tritonclient[grpc]
 
 for TEST in ${SUBTESTS}; do
     (cd ${TEST} && bash -ex test.sh && cd ..)


### PR DESCRIPTION
1. Resolves local vs system package errors around `pip` installation in Ubuntu 24.04 tests by removing the `pip install --upgrade pip`. The pip upgrade shouldn't be necessary for any installations in these tests.

Example error before this change:
```bash
$ pip install --upgrade pip
Requirement already satisfied: pip in /usr/lib/python3/dist-packages (24.0)
Collecting pip
  Using cached pip-24.3.1-py3-none-any.whl.metadata (3.7 kB)
Using cached pip-24.3.1-py3-none-any.whl (1.8 MB)
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 24.0
ERROR: Cannot uninstall pip 24.0, RECORD file not found. Hint: The package was installed by debian.
```

2. Replaces the [now-deprecated](https://docs.python.org/3/whatsnew/3.12.html#id3) unittest assertEquals with assertEqual to avoid the following error when running the tests: `"class has no attribute assertEquals"`
