### PR TITLE
Followup with some fixes

### DIFF
--- a/ci/L0_backend_vllm/metrics_test/test.sh
+++ b/ci/L0_backend_vllm/metrics_test/test.sh
@@ -75,11 +75,11 @@ run_test() {
         fi
     fi
 
+    set -e
+
     # TODO: Non-graceful shutdown when metrics are enabled.
     kill $SERVER_PID
     wait $SERVER_PID
-
-    set -e
 }
 
 RET=0


### PR DESCRIPTION
TODO:
[X] Fix non-graceful shut down
[ ] re-implement `build_async_engine_client_from_engine_args` for our use-case
[ ] implement ProxyStatLogger(VllmStatLoggerBase), which will be attached to a `MQLLMEngine` process and pass metrics updates via `multiprocessing.Queue` to the main stub process, so that TritonMetrics could be updated 