### PR TITLE
Setting shutdown asyncio event in a thread-safe manner

### DIFF
--- a/ci/L0_backend_vllm/metrics_test/test.sh
+++ b/ci/L0_backend_vllm/metrics_test/test.sh
@@ -75,11 +75,11 @@ run_test() {
         fi
     fi
 
+    set -e
+
     # TODO: Non-graceful shutdown when metrics are enabled.
     kill $SERVER_PID
     wait $SERVER_PID
-
-    set -e
 }
 
 RET=0

--- a/src/model.py
+++ b/src/model.py
@@ -228,7 +228,7 @@ class TritonPythonModel:
         # Run the engine in a separate thread running the AsyncIO event loop.
         self._llm_engine = None
         self._llm_engine_start_cv = threading.Condition()
-        self._llm_engine_shutdown_event = threading.Event()
+        self._llm_engine_shutdown_event = asyncio.Event()
         self._event_thread = threading.Thread(
             target=asyncio.run, args=(self._run_llm_engine(),)
         )
@@ -268,8 +268,7 @@ class TritonPythonModel:
                     self._llm_engine_start_cv.notify_all()
 
                 # Wait for the engine shutdown signal.
-                while not self._llm_engine_shutdown_event.is_set():
-                    await asyncio.sleep(0.1)  # Prevent busy-waiting
+                await self._llm_engine_shutdown_event.wait()
 
                 # Wait for the ongoing requests to complete.
                 while self._ongoing_request_count > 0:
@@ -801,7 +800,7 @@ class TritonPythonModel:
 
     def finalize(self):
         self.logger.log_info("[vllm] Issuing finalize to vllm backend")
-        self._llm_engine_shutdown_event.set()
+        self._event_loop.call_soon_threadsafe(self._llm_engine_shutdown_event.set)
 
         # Shutdown the event thread.
         if self._event_thread is not None:


### PR DESCRIPTION
It seems like we need to be careful, when using asyncio with multi-threading. The non-graceful shutdown was happening due to "RuntimeError: Non-thread-safe operation invoked on an event loop other than the current one\n\nA" (I started `asyncio.run` with `debug=True`). Thus I'm replacing asyncio with threading.

Tests: https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/129814805
tests ran for branch `oandreeva_metrics_refactor`, but the change is the same. I suggest to merge this commit to the current perf PR and merge perf PR to main, i.e. not wait for metrics follow up.