### PR TITLE
Fix the bge embedding model callback error

### DIFF
--- a/src/utils/request.py
+++ b/src/utils/request.py
@@ -365,7 +365,9 @@ class EmbedRequest(RequestBase):
         dims = None
         if "dimensions" in pooling_params_dict:
             dims = pooling_params_dict["dimensions"][0]
-            pooling_params = PoolingParams(dimensions=dims, task="embed")
+            pooling_params = PoolingParams(
+                dimensions=dims, task="embed", skip_reading_prefix_cache=False
+            )
         return pooling_params
 
     def create_response(self, request_output: PoolingRequestOutput[EmbeddingOutput]):


### PR DESCRIPTION
- Add missing attr of PoolingParams

Hi all, I try to deploy [BAAI/bge-large-en](https://huggingface.co/BAAI/bge-large-en). It establishes server properly but fail to inference.
```bash
curl -X POST http://localhost:8000/v2/models/bge_emb/generate \
  -H "Content-Type: application/json" \
  -d '{
    "embedding_request": "{\"input\": \"Test\"}"
  }'
```

Below is the error log
```
(EngineCore_DPO pid=4141) Exception in thread Thread-5 (process_input_sockets):
(EngineCore_DPO pid=4141) Traceback (most recent call last):
  File "/usr/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.12/threading.py", line 1010, in run
    self.target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 1025, in process_input_sockets
    request = add_request_decoder.decode(data_frames)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/v1/serial_utils.py", line 311, in decode
    return self.decoder.decode(bufs[0])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
msgpec.ValidationError: Expected 'bool', got 'None' - at '$[4][10]'
```

After assign Boolean value the model can inference properly. Thanks