### PR TITLE
feat: Add `GPU_DEVICE_IDS` parameter support for pinning multi-GPU models to specific GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,24 @@ Specifically,
 and
 [here](https://github.com/vllm-project/vllm/blob/ee8217e5bee5860469204ee57077a91138c9af02/vllm/engine/arg_utils.py#L201).
 
-For multi-GPU support, EngineArgs like tensor_parallel_size can be specified in
-[model.json](samples/model_repository/vllm_model/1/model.json).
+For multi-GPU support, EngineArgs such as `tensor_parallel_size` can be specified in [model.json](samples/model_repository/vllm_model/1/model.json).
+When using multi-GPU models, the instance group `kind` must be set to `KIND_MODEL` in `config.pbtxt`.
+
+By default, vLLM selects from all GPUs visible to the Triton process. To pin a multi-GPU model to a specific subset of GPUs, you can provide the `GPU_DEVICE_IDS` parameter in `config.pbtxt`. This is useful for co-locating multiple models with different GPU requirements on a single Triton server.
+
+```protobuf
+instance_group [
+  {
+    count: 1
+    kind: KIND_MODEL
+  }
+]
+parameters {
+  key: "GPU_DEVICE_IDS"
+  value: { string_value: "1,2" }
+}
+```
+The number of GPU IDs specified in `GPU_DEVICE_IDS` must match the total parallelism world size (`tensor_parallel_size` * `pipeline_parallel_size`).
 
 Note: vLLM greedily consume up to 90% of the GPU's memory under default settings.
 The sample model updates this behavior by setting gpu_memory_utilization to 50%.

--- a/ci/L0_multi_gpu_vllm/vllm_backend/test.sh
+++ b/ci/L0_multi_gpu_vllm/vllm_backend/test.sh
@@ -90,8 +90,10 @@ function run_test_with_server() {
     fi
     set -e
 
-    kill $SERVER_PID
-    wait $SERVER_PID
+    if kill -0 "$SERVER_PID" 2>/dev/null; then
+        kill "$SERVER_PID" || true
+    fi
+    wait "$SERVER_PID" 2>/dev/null || true
 }
 
 function run_multi_gpu_test() {
@@ -132,6 +134,7 @@ function create_gpu_device_ids_model() {
     local VLLM_CONFIG="${MODEL_DIR}/1/model.json"
 
     cp -r "${SAMPLE_MODELS_REPO}/vllm_model" "${MODEL_DIR}"
+    validate_file_contains "KIND_MODEL" "${TRITON_CONFIG}"
     sed -i "3s/^/    \"tensor_parallel_size\": ${TP},\n/" "${VLLM_CONFIG}"
     if [ $TP -ne "1" ]; then
         jq --arg backend $DISTRIBUTED_EXECUTOR_BACKEND \

--- a/ci/L0_multi_gpu_vllm/vllm_backend/test.sh
+++ b/ci/L0_multi_gpu_vllm/vllm_backend/test.sh
@@ -64,7 +64,7 @@ function run_test_with_server() {
     local TEST_NAME="${1}"
     local TEST_METHOD="${2}"
 
-    SERVER_LOG="./${TEST_NAME}--server.log"
+    SERVER_LOG="./${TEST_NAME}.server.log"
     run_server
     if [ "$SERVER_PID" == "0" ]; then
         cat "$SERVER_LOG"
@@ -73,7 +73,7 @@ function run_test_with_server() {
     fi
 
     set +e
-    CLIENT_LOG="./${TEST_NAME}--client.log"
+    CLIENT_LOG="./${TEST_NAME}.client.log"
     python3 "$CLIENT_PY" "${TEST_METHOD}" -v > "$CLIENT_LOG" 2>&1
 
     if [ $? -ne 0 ]; then

--- a/ci/L0_multi_gpu_vllm/vllm_backend/test.sh
+++ b/ci/L0_multi_gpu_vllm/vllm_backend/test.sh
@@ -175,25 +175,25 @@ function run_gpu_device_ids_validation_tests() {
     # Clear env vars from other tests
     unset TEST_MODEL GPU_DEVICE_IDS KIND TENSOR_PARALLELISM INSTANCE_COUNT
 
-    local BAD_FORMAT="vllm_gpu_device_ids_bad_format"
-    local BAD_WHITESPACE="vllm_gpu_device_ids_bad_whitespace"
-    local BAD_NEGATIVE="vllm_gpu_device_ids_bad_negative"
-    local BAD_DUPLICATE="vllm_gpu_device_ids_bad_duplicate"
-    local BAD_COUNT="vllm_gpu_device_ids_bad_count"
+    local INVALID_FORMAT="vllm_invalid_format_gpu_device_ids"
+    local INVALID_WHITESPACE="vllm_invalid_whitespace_gpu_device_ids"
+    local INVALID_NEGATIVE="vllm_invalid_negative_gpu_device_ids"
+    local INVALID_DUPLICATE="vllm_invalid_duplicate_gpu_device_ids"
+    local INVALID_COUNT="vllm_invalid_count_gpu_device_ids"
 
     rm -rf models && mkdir -p models
     # Non-integer string: triggers parse ValueError
-    create_gpu_device_ids_model "${BAD_FORMAT}" "abc" "${TP}" "${DISTRIBUTED_EXECUTOR_BACKEND}"
-    # Whitespace-only: same parse ValueError path as bad_format
-    create_gpu_device_ids_model "${BAD_WHITESPACE}" " " "${TP}" "${DISTRIBUTED_EXECUTOR_BACKEND}"
+    create_gpu_device_ids_model "${INVALID_FORMAT}" "abc" "${TP}" "${DISTRIBUTED_EXECUTOR_BACKEND}"
+    # Whitespace-only: same parse ValueError path as invalid_format
+    create_gpu_device_ids_model "${INVALID_WHITESPACE}" " " "${TP}" "${DISTRIBUTED_EXECUTOR_BACKEND}"
     # Negative GPU ID: triggers negative-ID check
-    create_gpu_device_ids_model "${BAD_NEGATIVE}" "-1" "${TP}" "${DISTRIBUTED_EXECUTOR_BACKEND}"
+    create_gpu_device_ids_model "${INVALID_NEGATIVE}" "-1" "${TP}" "${DISTRIBUTED_EXECUTOR_BACKEND}"
     # Duplicate GPU IDs: triggers duplicate check
-    create_gpu_device_ids_model "${BAD_DUPLICATE}" "0,0" "${TP}" "${DISTRIBUTED_EXECUTOR_BACKEND}"
+    create_gpu_device_ids_model "${INVALID_DUPLICATE}" "0,0" "${TP}" "${DISTRIBUTED_EXECUTOR_BACKEND}"
     # Fewer IDs than world_size: triggers count-mismatch check
-    create_gpu_device_ids_model "${BAD_COUNT}" "0" "${TP}" "${DISTRIBUTED_EXECUTOR_BACKEND}"
+    create_gpu_device_ids_model "${INVALID_COUNT}" "0" "${TP}" "${DISTRIBUTED_EXECUTOR_BACKEND}"
 
-    export INVALID_GPU_DEVICE_IDS_MODELS="${BAD_FORMAT},${BAD_WHITESPACE},${BAD_NEGATIVE},${BAD_DUPLICATE},${BAD_COUNT}"
+    export INVALID_GPU_DEVICE_IDS_MODELS="${INVALID_FORMAT},${INVALID_WHITESPACE},${INVALID_NEGATIVE},${INVALID_DUPLICATE},${INVALID_COUNT}"
 
     echo "Running GPU_DEVICE_IDS validation tests with invalid configs"
     run_test_with_server \

--- a/ci/L0_multi_gpu_vllm/vllm_backend/test.sh
+++ b/ci/L0_multi_gpu_vllm/vllm_backend/test.sh
@@ -161,10 +161,19 @@ function run_gpu_device_ids_test() {
     rm -rf models && mkdir -p models
     create_gpu_device_ids_model "${TEST_MODEL}" "${GPU_IDS}" "${TP}" "${DISTRIBUTED_EXECUTOR_BACKEND}"
 
-    echo "Running GPU_DEVICE_IDS happy-path test with gpu_ids=${GPU_IDS}, tp=${TP}"
+    echo "Running valid GPU_DEVICE_IDS test with gpu_ids=${GPU_IDS}, tp=${TP}"
     run_test_with_server \
-        "vllm_gpu_device_ids_test--happy_path" \
+        "vllm_valid_gpu_device_ids_test--${GPU_IDS}_tp${TP}" \
         "VLLMMultiGPUTest.test_gpu_device_ids"
+
+    # Verify that _validate_device_config logged the GPU_DEVICE_IDS specified.
+    local EXPECTED_LOG_MSG="Detected KIND_MODEL instance with GPU_DEVICE_IDS specified"
+    if ! grep -q "${EXPECTED_LOG_MSG}" "${SERVER_LOG}"; then
+        echo -e "\n***\n*** ERROR: Expected log message not found in ${SERVER_LOG}:" \
+                "\n***   '${EXPECTED_LOG_MSG}'\n***"
+        RET=1
+    fi
+
     unset GPU_DEVICE_IDS
 }
 
@@ -222,6 +231,7 @@ done
 
 # Test GPU_DEVICE_IDS parameter for per-model GPU pinning with KIND_MODEL
 run_gpu_device_ids_test "0,1" "2" "${DISTRIBUTED_EXECUTOR_BACKEND}"
+run_gpu_device_ids_test "1" "1" "${DISTRIBUTED_EXECUTOR_BACKEND}"
 run_gpu_device_ids_validation_tests "${DISTRIBUTED_EXECUTOR_BACKEND}"
 
 ### Results

--- a/ci/L0_multi_gpu_vllm/vllm_backend/test.sh
+++ b/ci/L0_multi_gpu_vllm/vllm_backend/test.sh
@@ -59,6 +59,41 @@ function validate_file_contains() {
     fi
 }
 
+# Helper: start server, run one Python test method, stop server.
+function run_test_with_server() {
+    local TEST_NAME="${1}"
+    local TEST_METHOD="${2}"
+
+    SERVER_LOG="./${TEST_NAME}--server.log"
+    run_server
+    if [ "$SERVER_PID" == "0" ]; then
+        cat "$SERVER_LOG"
+        echo -e "\n***\n*** Failed to start $SERVER\n***"
+        exit 1
+    fi
+
+    set +e
+    CLIENT_LOG="./${TEST_NAME}--client.log"
+    python3 "$CLIENT_PY" "${TEST_METHOD}" -v > "$CLIENT_LOG" 2>&1
+
+    if [ $? -ne 0 ]; then
+        cat "$CLIENT_LOG"
+        echo -e "\n***\n*** ${TEST_NAME} FAILED.\n***"
+        RET=1
+    else
+        check_test_results $TEST_RESULT_FILE $EXPECTED_NUM_TESTS
+        if [ $? -ne 0 ]; then
+            cat "$CLIENT_LOG"
+            echo -e "\n***\n*** Test Result Verification FAILED.\n***"
+            RET=1
+        fi
+    fi
+    set -e
+
+    kill $SERVER_PID
+    wait $SERVER_PID
+}
+
 function run_multi_gpu_test() {
     export KIND="${1}"
     export TENSOR_PARALLELISM="${2}"
@@ -81,50 +116,102 @@ function run_multi_gpu_test() {
     # Assert the correct kind is set in case the template config changes in the future
     validate_file_contains "${KIND}" "${TEST_MODEL_TRITON_CONFIG}"
 
-    # Start server
     echo "Running multi-GPU test with kind=${KIND}, tp=${TENSOR_PARALLELISM}, instance_count=${INSTANCE_COUNT}"
-    SERVER_LOG="./vllm_multi_gpu_test--${KIND}_tp${TENSOR_PARALLELISM}_count${INSTANCE_COUNT}--server.log"
-    run_server
-    if [ "$SERVER_PID" == "0" ]; then
-        cat $SERVER_LOG
-        echo -e "\n***\n*** Failed to start $SERVER\n***"
-        exit 1
+    run_test_with_server \
+        "vllm_multi_gpu_test--${KIND}_tp${TENSOR_PARALLELISM}_count${INSTANCE_COUNT}" \
+        "VLLMMultiGPUTest.test_multi_gpu_model"
+}
+
+function create_gpu_device_ids_model() {
+    local MODEL_NAME="${1}"
+    local GPU_IDS="${2}"
+    local TP="${3}"
+    local DISTRIBUTED_EXECUTOR_BACKEND="${4}"
+    local MODEL_DIR="models/${MODEL_NAME}"
+    local TRITON_CONFIG="${MODEL_DIR}/config.pbtxt"
+    local VLLM_CONFIG="${MODEL_DIR}/1/model.json"
+
+    cp -r "${SAMPLE_MODELS_REPO}/vllm_model" "${MODEL_DIR}"
+    sed -i "3s/^/    \"tensor_parallel_size\": ${TP},\n/" "${VLLM_CONFIG}"
+    if [ $TP -ne "1" ]; then
+        jq --arg backend $DISTRIBUTED_EXECUTOR_BACKEND \
+            '. += {"distributed_executor_backend":$backend}' \
+            "${VLLM_CONFIG}" > "temp.json"
+        mv temp.json "${VLLM_CONFIG}"
     fi
+    cat >> "${TRITON_CONFIG}" << EOF
+parameters {
+  key: "GPU_DEVICE_IDS"
+  value: { string_value: "${GPU_IDS}" }
+}
+EOF
+}
 
-    # Run unit tests
-    set +e
-    CLIENT_LOG="./vllm_multi_gpu_test--${KIND}_tp${TENSOR_PARALLELISM}_count${INSTANCE_COUNT}--client.log"
-    python3 $CLIENT_PY -v > $CLIENT_LOG 2>&1
+function run_gpu_device_ids_test() {
+    local GPU_IDS="${1}"
+    local TP="${2}"
+    local DISTRIBUTED_EXECUTOR_BACKEND="${3}"
 
-    if [ $? -ne 0 ]; then
-        cat $CLIENT_LOG
-        echo -e "\n***\n*** Running $CLIENT_PY FAILED. \n***"
-        RET=1
-    else
-        check_test_results $TEST_RESULT_FILE $EXPECTED_NUM_TESTS
-        if [ $? -ne 0 ]; then
-            cat $CLIENT_LOG
-            echo -e "\n***\n*** Test Result Verification FAILED.\n***"
-            RET=1
-        fi
-    fi
-    set -e
+    # Clear env vars from other tests
+    unset KIND TENSOR_PARALLELISM INSTANCE_COUNT INVALID_GPU_DEVICE_IDS_MODELS
 
-    # Cleanup
-    kill $SERVER_PID
-    wait $SERVER_PID
+    export TEST_MODEL="vllm_gpu_device_ids_tp${TP}"
+    export GPU_DEVICE_IDS="${GPU_IDS}"
+
+    rm -rf models && mkdir -p models
+    create_gpu_device_ids_model "${TEST_MODEL}" "${GPU_IDS}" "${TP}" "${DISTRIBUTED_EXECUTOR_BACKEND}"
+
+    echo "Running GPU_DEVICE_IDS happy-path test with gpu_ids=${GPU_IDS}, tp=${TP}"
+    run_test_with_server \
+        "vllm_gpu_device_ids_test--happy_path" \
+        "VLLMMultiGPUTest.test_gpu_device_ids"
+    unset GPU_DEVICE_IDS
+}
+
+function run_gpu_device_ids_validation_tests() {
+    local DISTRIBUTED_EXECUTOR_BACKEND="${1}"
+    local TP="2"
+
+    # Clear env vars from other tests
+    unset TEST_MODEL GPU_DEVICE_IDS KIND TENSOR_PARALLELISM INSTANCE_COUNT
+
+    local BAD_FORMAT="vllm_gpu_device_ids_bad_format"
+    local BAD_WHITESPACE="vllm_gpu_device_ids_bad_whitespace"
+    local BAD_NEGATIVE="vllm_gpu_device_ids_bad_negative"
+    local BAD_DUPLICATE="vllm_gpu_device_ids_bad_duplicate"
+    local BAD_COUNT="vllm_gpu_device_ids_bad_count"
+
+    rm -rf models && mkdir -p models
+    # Non-integer string: triggers parse ValueError
+    create_gpu_device_ids_model "${BAD_FORMAT}" "abc" "${TP}" "${DISTRIBUTED_EXECUTOR_BACKEND}"
+    # Whitespace-only: same parse ValueError path as bad_format
+    create_gpu_device_ids_model "${BAD_WHITESPACE}" " " "${TP}" "${DISTRIBUTED_EXECUTOR_BACKEND}"
+    # Negative GPU ID: triggers negative-ID check
+    create_gpu_device_ids_model "${BAD_NEGATIVE}" "-1" "${TP}" "${DISTRIBUTED_EXECUTOR_BACKEND}"
+    # Duplicate GPU IDs: triggers duplicate check
+    create_gpu_device_ids_model "${BAD_DUPLICATE}" "0,0" "${TP}" "${DISTRIBUTED_EXECUTOR_BACKEND}"
+    # Fewer IDs than world_size: triggers count-mismatch check
+    create_gpu_device_ids_model "${BAD_COUNT}" "0" "${TP}" "${DISTRIBUTED_EXECUTOR_BACKEND}"
+
+    export INVALID_GPU_DEVICE_IDS_MODELS="${BAD_FORMAT},${BAD_WHITESPACE},${BAD_NEGATIVE},${BAD_DUPLICATE},${BAD_COUNT}"
+
+    echo "Running GPU_DEVICE_IDS validation tests with invalid configs"
+    run_test_with_server \
+        "vllm_gpu_device_ids_test--validation" \
+        "VLLMMultiGPUTest.test_invalid_gpu_device_ids"
+    unset INVALID_GPU_DEVICE_IDS_MODELS
 }
 
 ### Test
 rm -f *.log
 RET=0
+DISTRIBUTED_EXECUTOR_BACKEND="ray"
 
 # Test the various cases of kind, tensor parallelism, and instance count
 # for different ways to run multi-GPU models with vLLM on Triton
 KINDS="KIND_MODEL KIND_GPU"
 TPS="1 2"
 INSTANCE_COUNTS="1 2"
-DISTRIBUTED_EXECUTOR_BACKEND="ray"
 for kind in ${KINDS}; do
   for tp in ${TPS}; do
     for count in ${INSTANCE_COUNTS}; do
@@ -132,6 +219,10 @@ for kind in ${KINDS}; do
     done
   done
 done
+
+# Test GPU_DEVICE_IDS parameter for per-model GPU pinning with KIND_MODEL
+run_gpu_device_ids_test "0,1" "2" "${DISTRIBUTED_EXECUTOR_BACKEND}"
+run_gpu_device_ids_validation_tests "${DISTRIBUTED_EXECUTOR_BACKEND}"
 
 ### Results
 if [ $RET -eq 1 ]; then

--- a/ci/L0_multi_gpu_vllm/vllm_backend/vllm_multi_gpu_test.py
+++ b/ci/L0_multi_gpu_vllm/vllm_backend/vllm_multi_gpu_test.py
@@ -288,7 +288,7 @@ class VLLMMultiGPUTest(TestResultCollector):
             "invalid_format": "Expected a comma-separated list of integer GPU IDs",
             "invalid_whitespace": "Expected a comma-separated list of integer GPU IDs",
             "invalid_negative": "GPU IDs must be non-negative integers.",
-            "invalid_duplicate": "Each GPU ID must be unique.",
+            "invalid_duplicate": "Duplicate GPU_DEVICE_IDS:",
             "invalid_count": "must match the total parallelism world size",
         }
 

--- a/ci/L0_multi_gpu_vllm/vllm_backend/vllm_multi_gpu_test.py
+++ b/ci/L0_multi_gpu_vllm/vllm_backend/vllm_multi_gpu_test.py
@@ -50,6 +50,9 @@ class VLLMMultiGPUTest(TestResultCollector):
         pynvml.nvmlInit()
         self.triton_client = grpcclient.InferenceServerClient(url="localhost:8001")
 
+        # Minimum memory increase on a GPU indicating that a model was loaded on it.
+        self._GPU_LOAD_THRESHOLD_BYTES = 1024 * 1024 * 1024  # 1 GiB
+
     def get_gpu_memory_utilization(self, gpu_id):
         handle = pynvml.nvmlDeviceGetHandleByIndex(gpu_id)
         info = pynvml.nvmlDeviceGetMemoryInfo(handle)
@@ -91,7 +94,7 @@ class VLLMMultiGPUTest(TestResultCollector):
             memory_utilization = self.get_gpu_memory_utilization(gpu_id)
             print(f"GPU {gpu_id} Memory Utilization: {memory_utilization} bytes")
             memory_delta = memory_utilization - mem_util_before_loading_model[gpu_id]
-            if memory_delta > 0:
+            if memory_delta > self._GPU_LOAD_THRESHOLD_BYTES:
                 vllm_model_used_gpus += 1
                 gpu_memory_utilizations.append(memory_delta)
 
@@ -198,6 +201,112 @@ class VLLMMultiGPUTest(TestResultCollector):
             self.skipTest(msg)
 
         self._test_vllm_multi_gpu_utilization(model)
+
+    def _assert_model_loaded_on_pinned_gpus(
+        self, model_name: str, pinned_gpu_ids: list[int]
+    ):
+        """
+        Loads the specified model, runs a sanity-check inference, and asserts:
+
+        Every GPU listed in pinned_gpu_ids shows a significant memory increase,
+        confirming the model loaded on the GPUs specified by GPU_DEVICE_IDS.
+        Every GPU not listed in pinned_gpu_ids shows no significant memory increase,
+        confirming that CUDA_VISIBLE_DEVICES correctly restricted GPU visibility for vLLM.
+        """
+
+        all_gpu_ids = self.get_available_gpu_ids()
+        self.assertGreaterEqual(len(all_gpu_ids), 2, "Error: Detected single GPU")
+
+        pinned_set = set(pinned_gpu_ids)
+
+        print(f"\n\n=============== Before Loading {model_name} ===============")
+        mem_before = {}
+        for gpu_id in all_gpu_ids:
+            mem_before[gpu_id] = self.get_gpu_memory_utilization(gpu_id)
+            print(f"  GPU {gpu_id}: {mem_before[gpu_id]:,} bytes")
+
+        self.triton_client.load_model(model_name)
+        self._test_vllm_model(model_name)
+
+        print(f"\n\n=============== After Loading {model_name} ===============")
+        for gpu_id in all_gpu_ids:
+            mem_after = self.get_gpu_memory_utilization(gpu_id)
+            delta = mem_after - mem_before[gpu_id]
+            print(f"  GPU {gpu_id}: {mem_after:,} bytes  (delta: {delta:+,} bytes)")
+
+            if gpu_id in pinned_set:
+                self.assertGreater(
+                    delta,
+                    self._GPU_LOAD_THRESHOLD_BYTES,
+                    f"GPU {gpu_id} is listed in GPU_DEVICE_IDS={pinned_gpu_ids}, but its "
+                    f"memory usage increased by only {delta:,} bytes (threshold: "
+                    f"{self._GPU_LOAD_THRESHOLD_BYTES:,} bytes).",
+                )
+            else:
+                self.assertLessEqual(
+                    delta,
+                    self._GPU_LOAD_THRESHOLD_BYTES,
+                    f"GPU {gpu_id} is not listed in GPU_DEVICE_IDS={pinned_gpu_ids}, but its "
+                    f"memory usage increased by {delta:,} bytes, which exceeds the allowed threshold of "
+                    f"{self._GPU_LOAD_THRESHOLD_BYTES:,} bytes.",
+                )
+
+    def test_gpu_device_ids(self):
+        """
+        Tests that a KIND_MODEL instance with GPU_DEVICE_IDS specified loads on exactly
+        the requested GPUs and serves inference correctly.
+        """
+        model = os.environ.get("TEST_MODEL")
+        gpu_device_ids = os.environ.get("GPU_DEVICE_IDS")
+        if model is None or gpu_device_ids is None:
+            self.fail(
+                "Environment variables TEST_MODEL and GPU_DEVICE_IDS are required"
+            )
+
+        pinned_gpu_ids = [int(x.strip()) for x in gpu_device_ids.split(",")]
+        available_gpu_ids = self.get_available_gpu_ids()
+        for gpu_id in pinned_gpu_ids:
+            self.assertIn(
+                gpu_id,
+                available_gpu_ids,
+                f"GPU {gpu_id} in GPU_DEVICE_IDS is not available on this system",
+            )
+
+        self._assert_model_loaded_on_pinned_gpus(model, pinned_gpu_ids)
+
+    def test_invalid_gpu_device_ids(self):
+        """
+        Tests that models configured with invalid GPU_DEVICE_IDS values
+        are rejected at load time with clear and specific error messages.
+        """
+        invalid_models_str = os.environ.get("INVALID_GPU_DEVICE_IDS_MODELS")
+        if invalid_models_str is None:
+            self.fail("Environment variable INVALID_GPU_DEVICE_IDS_MODELS is not set")
+
+        invalid_models = [m.strip() for m in invalid_models_str.split(",") if m.strip()]
+        self.assertGreater(len(invalid_models), 0, "No invalid models specified")
+
+        # Maps a substring of the model name to the error fragment expected from
+        # _validate_device_config().
+        expected_errors = {
+            "bad_format": "Expected a comma-separated list of integer GPU IDs",
+            "bad_whitespace": "Expected a comma-separated list of integer GPU IDs",
+            "bad_negative": "GPU IDs must be non-negative integers.",
+            "bad_duplicate": "Each GPU ID must be unique.",
+            "bad_count": "must match the total parallelism world size",
+        }
+
+        for model in invalid_models:
+            matched_key = next((key for key in expected_errors if key in model), None)
+            self.assertIsNotNone(
+                matched_key,
+                f"Model name '{model}' does not match any expected error key: "
+                f"{list(expected_errors.keys())}",
+            )
+
+            expected_pattern = expected_errors[matched_key]
+            with self.assertRaisesRegex(InferenceServerException, expected_pattern):
+                self.triton_client.load_model(model)
 
     def tearDown(self):
         pynvml.nvmlShutdown()

--- a/ci/L0_multi_gpu_vllm/vllm_backend/vllm_multi_gpu_test.py
+++ b/ci/L0_multi_gpu_vllm/vllm_backend/vllm_multi_gpu_test.py
@@ -50,9 +50,6 @@ class VLLMMultiGPUTest(TestResultCollector):
         pynvml.nvmlInit()
         self.triton_client = grpcclient.InferenceServerClient(url="localhost:8001")
 
-        # Minimum memory increase on a GPU indicating that a model was loaded on it.
-        self._GPU_LOAD_THRESHOLD_BYTES = 1024 * 1024 * 1024  # 1 GiB
-
     def get_gpu_memory_utilization(self, gpu_id):
         handle = pynvml.nvmlDeviceGetHandleByIndex(gpu_id)
         info = pynvml.nvmlDeviceGetMemoryInfo(handle)
@@ -94,7 +91,7 @@ class VLLMMultiGPUTest(TestResultCollector):
             memory_utilization = self.get_gpu_memory_utilization(gpu_id)
             print(f"GPU {gpu_id} Memory Utilization: {memory_utilization} bytes")
             memory_delta = memory_utilization - mem_util_before_loading_model[gpu_id]
-            if memory_delta > self._GPU_LOAD_THRESHOLD_BYTES:
+            if memory_delta > 0:
                 vllm_model_used_gpus += 1
                 gpu_memory_utilizations.append(memory_delta)
 
@@ -237,18 +234,17 @@ class VLLMMultiGPUTest(TestResultCollector):
             if gpu_id in pinned_set:
                 self.assertGreater(
                     delta,
-                    self._GPU_LOAD_THRESHOLD_BYTES,
+                    0,
                     f"GPU {gpu_id} is listed in GPU_DEVICE_IDS={pinned_gpu_ids}, but its "
-                    f"memory usage increased by only {delta:,} bytes (threshold: "
-                    f"{self._GPU_LOAD_THRESHOLD_BYTES:,} bytes).",
+                    f"memory usage did not increase after loading the model.",
                 )
             else:
                 self.assertLessEqual(
                     delta,
-                    self._GPU_LOAD_THRESHOLD_BYTES,
+                    0,
                     f"GPU {gpu_id} is not listed in GPU_DEVICE_IDS={pinned_gpu_ids}, but its "
-                    f"memory usage increased by {delta:,} bytes, which exceeds the allowed threshold of "
-                    f"{self._GPU_LOAD_THRESHOLD_BYTES:,} bytes.",
+                    f"memory usage increased by {delta:,} bytes. "
+                    f"CUDA_VISIBLE_DEVICES should have hidden this GPU from vLLM.",
                 )
 
     def test_gpu_device_ids(self):

--- a/ci/L0_multi_gpu_vllm/vllm_backend/vllm_multi_gpu_test.py
+++ b/ci/L0_multi_gpu_vllm/vllm_backend/vllm_multi_gpu_test.py
@@ -289,11 +289,11 @@ class VLLMMultiGPUTest(TestResultCollector):
         # Maps a substring of the model name to the error fragment expected from
         # _validate_device_config().
         expected_errors = {
-            "bad_format": "Expected a comma-separated list of integer GPU IDs",
-            "bad_whitespace": "Expected a comma-separated list of integer GPU IDs",
-            "bad_negative": "GPU IDs must be non-negative integers.",
-            "bad_duplicate": "Each GPU ID must be unique.",
-            "bad_count": "must match the total parallelism world size",
+            "invalid_format": "Expected a comma-separated list of integer GPU IDs",
+            "invalid_whitespace": "Expected a comma-separated list of integer GPU IDs",
+            "invalid_negative": "GPU IDs must be non-negative integers.",
+            "invalid_duplicate": "Each GPU ID must be unique.",
+            "invalid_count": "must match the total parallelism world size",
         }
 
         for model in invalid_models:

--- a/src/model.py
+++ b/src/model.py
@@ -312,27 +312,72 @@ class TritonPythonModel:
         triton_device_id = int(self.args["model_instance_device_id"])
         triton_instance = f"{self.args['model_name']}_{triton_device_id}"
 
-        # Triton's current definition of KIND_GPU makes assumptions that
-        # models only use a single GPU. For multi-GPU models, the recommendation
-        # is to specify KIND_MODEL to acknowledge that the model will take control
-        # of the devices made available to it.
-        # NOTE: Consider other parameters that would indicate multi-GPU in the future.
         tp_size = int(self.vllm_engine_config.get("tensor_parallel_size", 1))
         pp_size = int(self.vllm_engine_config.get("pipeline_parallel_size", 1))
-        if (tp_size * pp_size) > 1 and triton_kind == "GPU":
-            raise ValueError(
-                "KIND_GPU is currently for single-GPU models, please specify KIND_MODEL "
-                "in the model's config.pbtxt for multi-GPU models"
-            )
+        world_size = tp_size * pp_size
 
-        # If KIND_GPU is specified, specify the device ID assigned by Triton to ensure that
-        # multiple model instances do not oversubscribe the same default device.
-        if triton_kind == "GPU" and triton_device_id >= 0:
-            self.logger.log_info(
-                f"Detected KIND_GPU model instance, explicitly setting GPU device={triton_device_id} for {triton_instance}"
-            )
-            # vLLM doesn't currently (v0.4.2) expose device selection in the APIs
-            os.environ["CUDA_VISIBLE_DEVICES"] = str(triton_device_id)
+        if triton_kind == "GPU":
+            # Triton's current definition of KIND_GPU makes assumptions that
+            # models only use a single GPU. For multi-GPU models, the recommendation
+            # is to specify KIND_MODEL to acknowledge that the model will take control
+            # of the devices made available to it.
+            if world_size > 1:
+                raise ValueError(
+                    "KIND_GPU is currently for single-GPU models, please specify KIND_MODEL "
+                    "in the model's config.pbtxt for multi-GPU models"
+                )
+
+            # If KIND_GPU is specified, specify the device ID assigned by Triton to ensure that
+            # multiple model instances do not oversubscribe the same default device.
+            if triton_device_id >= 0:
+                self.logger.log_info(
+                    f"Detected KIND_GPU model instance, explicitly setting GPU device={triton_device_id} for {triton_instance}"
+                )
+                # vLLM doesn't currently (v0.4.2) expose device selection in the APIs
+                os.environ["CUDA_VISIBLE_DEVICES"] = str(triton_device_id)
+
+        elif triton_kind == "MODEL":
+            # KIND_MODEL defers device placement to the backend/engine.
+            # If the user provides a GPU_DEVICE_IDS parameter, pin this
+            # instance to those specific GPUs via CUDA_VISIBLE_DEVICES.
+            gpu_device_ids = self._get_string_config_param("GPU_DEVICE_IDS")
+            if gpu_device_ids:
+                try:
+                    gpu_ids = [int(x.strip()) for x in gpu_device_ids.split(",")]
+                except ValueError:
+                    raise ValueError(
+                        f"Invalid value for GPU_DEVICE_IDS: '{gpu_device_ids}'. "
+                        f"Expected a comma-separated list of integer GPU IDs (e.g., '0,1,2')."
+                    )
+
+                negative_ids = [gpu_id for gpu_id in gpu_ids if gpu_id < 0]
+                if negative_ids:
+                    raise ValueError(
+                        f"GPU_DEVICE_IDS contains invalid GPU ID(s): {negative_ids}. "
+                        f"GPU IDs must be non-negative integers."
+                    )
+
+                duplicates = [gpu_id for gpu_id in gpu_ids if gpu_ids.count(gpu_id) > 1]
+                if duplicates:
+                    raise ValueError(
+                        f"GPU_DEVICE_IDS contains duplicate GPU ID(s): {sorted(set(duplicates))}. "
+                        f"Each GPU ID must be unique."
+                    )
+
+                if world_size > 1 and len(gpu_ids) != world_size:
+                    raise ValueError(
+                        f"The number of GPU IDs specified in GPU_DEVICE_IDS "
+                        f"parameter must match the total parallelism world size "
+                        f"(tensor_parallel_size({tp_size}) * pipeline_parallel_size({pp_size}) "
+                        f"= {tp_size * pp_size})."
+                    )
+
+                cuda_visible = ",".join(str(gpu_id) for gpu_id in gpu_ids)
+                self.logger.log_info(
+                    f"Detected KIND_MODEL instance with GPU_DEVICE_IDS specified. "
+                    f"Setting CUDA_VISIBLE_DEVICES={cuda_visible} for {triton_instance}."
+                )
+                os.environ["CUDA_VISIBLE_DEVICES"] = cuda_visible
 
     def _setup_lora(self):
         self.enable_lora = False
@@ -384,6 +429,12 @@ class TritonPythonModel:
             self.model_config["parameters"][param_name]["string_value"].lower()
             == "true"
         )
+
+    def _get_string_config_param(self, param_name: str) -> str:
+        params = self.model_config.get("parameters", {})
+        if param_name in params:
+            return params[param_name].get("string_value", "")
+        return ""
 
     def _response_loop(self):
         while True:

--- a/src/model.py
+++ b/src/model.py
@@ -334,7 +334,7 @@ class TritonPythonModel:
                 self.logger.log_info(
                     f"Detected KIND_GPU model instance, explicitly setting GPU device={triton_device_id} for {triton_instance}"
                 )
-                # vLLM doesn't currently (v0.4.2) expose device selection in the APIs
+                # vLLM doesn't currently (v0.20.1) expose device selection in the APIs
                 os.environ["CUDA_VISIBLE_DEVICES"] = str(triton_device_id)
 
         elif triton_kind == "MODEL":

--- a/src/model.py
+++ b/src/model.py
@@ -31,6 +31,7 @@ import os
 import queue
 import threading
 import traceback
+from collections import Counter
 from typing import Dict, List
 
 import numpy as np
@@ -357,18 +358,11 @@ class TritonPythonModel:
                         f"GPU IDs must be non-negative integers."
                     )
 
-                seen_gpu_ids = set()
-                duplicates = set()
-                for gpu_id in gpu_ids:
-                    if gpu_id in seen_gpu_ids:
-                        duplicates.add(gpu_id)
-                    else:
-                        seen_gpu_ids.add(gpu_id)
+                duplicates = [
+                    gpu_id for gpu_id, count in Counter(gpu_ids).items() if count > 1
+                ]
                 if duplicates:
-                    raise ValueError(
-                        f"GPU_DEVICE_IDS contains duplicate GPU ID(s): {sorted(duplicates)}. "
-                        f"Each GPU ID must be unique."
-                    )
+                    raise ValueError(f"Duplicate GPU_DEVICE_IDS: {sorted(duplicates)}")
 
                 if world_size > 1 and len(gpu_ids) != world_size:
                     raise ValueError(

--- a/src/model.py
+++ b/src/model.py
@@ -357,10 +357,16 @@ class TritonPythonModel:
                         f"GPU IDs must be non-negative integers."
                     )
 
-                duplicates = [gpu_id for gpu_id in gpu_ids if gpu_ids.count(gpu_id) > 1]
+                seen_gpu_ids = set()
+                duplicates = set()
+                for gpu_id in gpu_ids:
+                    if gpu_id in seen_gpu_ids:
+                        duplicates.add(gpu_id)
+                    else:
+                        seen_gpu_ids.add(gpu_id)
                 if duplicates:
                     raise ValueError(
-                        f"GPU_DEVICE_IDS contains duplicate GPU ID(s): {sorted(set(duplicates))}. "
+                        f"GPU_DEVICE_IDS contains duplicate GPU ID(s): {sorted(duplicates)}. "
                         f"Each GPU ID must be unique."
                     )
 


### PR DESCRIPTION
Adds support for a `GPU_DEVICE_IDS` model configuration parameter so `KIND_MODEL` instances can be pinned to specific GPUs by setting `CUDA_VISIBLE_DEVICES`, with CI coverage to validate correct pinning and error handling.
