### PR TITLE
test: Fix various vLLM tests

### DIFF
--- a/ci/L0_backend_vllm/enabled_stream/enabled_stream_test.py
+++ b/ci/L0_backend_vllm/enabled_stream/enabled_stream_test.py
@@ -1,4 +1,4 @@
-# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,8 +45,8 @@ class VLLMTritonStreamTest(AsyncTestResultCollector):
         sampling_parameters=SAMPLING_PARAMETERS,
         stream=True,
         exclude_input_in_output=None,
-        expected_output=None,
         expect_error=False,
+        expected_joined_output=None,
     ):
         async with grpcclient.InferenceServerClient(
             url="localhost:8001"
@@ -84,13 +84,15 @@ class VLLMTritonStreamTest(AsyncTestResultCollector):
                 output = result.as_numpy("text_output")
                 self.assertIsNotNone(output, "`text_output` should not be None")
                 final_response.append(str(output[0], encoding="utf-8"))
-            if expected_output is not None:
+            if expected_joined_output is not None:
+                self.assertGreater(len(final_response), 1)
+                final_response = "".join(final_response)
                 self.assertEqual(
                     final_response,
-                    expected_output,
+                    expected_joined_output,
                     'Expected to receive the following response: "{}",\
                     but received "{}".'.format(
-                        expected_output, final_response
+                        expected_joined_output, final_response
                     ),
                 )
 
@@ -110,35 +112,19 @@ class VLLMTritonStreamTest(AsyncTestResultCollector):
         Verifying that streaming request returns only generated diffs, which
         is default behaviour for `stream=True`.
         """
-        expected_output = [
-            " the",
-            " one",
-            " that",
-            " is",
-            " most",
-            " likely",
-            " to",
-            " be",
-            " killed",
-            " by",
-            " a",
-            " car",
-            ".",
-            "\n",
-            "I",
-            "'m",
-        ]
-        await self._test_vllm_model(expected_output=expected_output)
+        await self._test_vllm_model(
+            expected_joined_output=(
+                " the one that is most likely to be killed by a car.\nI'm"
+            ),
+        )
 
     async def test_vllm_model_enabled_stream_exclude_input_in_output_false(self):
         """
         Verifying that streaming request returns only generated diffs even if
         `exclude_input_in_output` is set to False explicitly.
         """
-        expected_output = "Error generating stream: When streaming, `exclude_input_in_output` = False is not allowed."
         await self._test_vllm_model(
             exclude_input_in_output=False,
-            expected_output=expected_output,
             expect_error=True,
         )
 

--- a/ci/L0_multi_gpu_vllm/test.sh
+++ b/ci/L0_multi_gpu_vllm/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -28,7 +28,7 @@
 RET=0
 SUBTESTS="vllm_backend multi_lora"
 
-python3 -m pip install tritonclient[grpc]
+python3 -m pip install tritonclient[grpc] ray==2.55.0
 
 for TEST in ${SUBTESTS}; do
     (cd ${TEST} && bash -ex test.sh && cd ..)


### PR DESCRIPTION
Cherry-pick of #128 onto r26.04.

## Changes
- Fix various vLLM CI test issues

## Cherry-picked from
https://github.com/triton-inference-server/vllm_backend/pull/128