### PR TITLE
Fix typo: _aync_engine_args -> _async_engine_args

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -184,7 +184,7 @@ class TritonPythonModel:
         # TODO: Move the check into _setup_metrics().
         self._enable_metrics = (
             self._get_bool_config_param("REPORT_CUSTOM_METRICS")
-            and not self._aync_engine_args.disable_log_stats
+            and not self._async_engine_args.disable_log_stats
         )
 
         # Setup vLLM metrics
@@ -225,7 +225,7 @@ class TritonPythonModel:
         self._setup_lora()
 
         # Create an AsyncEngineArgs from the config from JSON
-        self._aync_engine_args = AsyncEngineArgs(**self.vllm_engine_config)
+        self._async_engine_args = AsyncEngineArgs(**self.vllm_engine_config)
 
     def _init_engine(self):
         # Run the engine in a separate thread running the AsyncIO event loop.
@@ -266,7 +266,7 @@ class TritonPythonModel:
             # statement.
             # TODO: Metrics should work with ZMQ enabled.
             async with build_async_engine_client_from_engine_args(
-                engine_args=self._aync_engine_args,
+                engine_args=self._async_engine_args,
                 logger=self.logger,
                 disable_frontend_multiprocessing=self._enable_metrics,
                 stat_loggers=self._vllm_metrics,


### PR DESCRIPTION
### Summary

Corrects a misspelled internal variable name in `src/model.py`: `_aync_engine_args` is renamed to `_async_engine_args` (3 occurrences). The variable holds the parsed AsyncEngineArgs, so the corrected spelling matches its meaning and the surrounding naming.

### Changes

- `src/model.py`: rename `_aync_engine_args` -> `_async_engine_args` (declaration and both usages).

### Notes

- No behavioral change; this is a private attribute renamed consistently within the file.
- Verified with `python -m py_compile src/model.py`.
