### PR TITLE
docs: remove non-existent histogram_best_of_request metric from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,8 +253,6 @@ histogram_e2e_time_request
 histogram_num_prompt_tokens_request
 # Number of generation tokens processed.
 histogram_num_generation_tokens_request
-# Histogram of the best_of request parameter.
-histogram_best_of_request
 # Histogram of the n request parameter.
 histogram_n_request
 ```


### PR DESCRIPTION
### Summary

The README documents a `histogram_best_of_request` metric that the vLLM backend does not emit. There is no reference to this metric anywhere in the backend source (e.g. `src/utils/metrics.py`), so listing it is misleading for users wiring up metric collection.

### Changes

- `README.md`: remove the two lines describing the non-existent `histogram_best_of_request` metric.

### Notes

- Documentation-only change.
- Confirmed the metric name does not appear in the backend source.
