### PR TITLE
fix: render prompts before vLLM generation

### DIFF
--- a/ci/L0_backend_vllm/vllm_backend/test.sh
+++ b/ci/L0_backend_vllm/vllm_backend/test.sh
@@ -99,6 +99,11 @@ else
         RET=1
     fi
 fi
+
+if grep -q "Passing raw prompts to InputProcessor is deprecated" "$SERVER_LOG"; then
+    echo -e "\n***\n*** Raw prompt deprecation warning found.\n***"
+    RET=1
+fi
 set -e
 
 kill $SERVER_PID

--- a/src/model.py
+++ b/src/model.py
@@ -515,6 +515,7 @@ class TritonPythonModel:
                     request = GenerateRequest(
                         request,
                         self._llm_engine.generate,
+                        self._llm_engine.renderer.render_cmpl_async,
                         self.output_dtype,
                         self.logger,
                         self.lora_repository,
@@ -524,6 +525,7 @@ class TritonPythonModel:
                     request = GenerateRequest(
                         request,
                         self._llm_engine.generate,
+                        self._llm_engine.renderer.render_cmpl_async,
                         self.output_dtype,
                         self.logger,
                     )

--- a/src/utils/request.py
+++ b/src/utils/request.py
@@ -77,12 +77,14 @@ class GenerateRequest(RequestBase):
         self,
         request,
         executor_callback: Callable,
+        renderer_callback: Callable,
         output_dtype: np.dtype,
         logger,
         lora_repository: Optional[Dict[str, str]] = None,
         supported_loras: Optional[List[str]] = None,
     ):
         super().__init__(request, executor_callback, output_dtype, logger)
+        self.renderer_callback = renderer_callback
         # Attributes for generate requests
         if lora_repository is not None:
             self.lora_repository = lora_repository
@@ -96,6 +98,7 @@ class GenerateRequest(RequestBase):
         ).as_numpy()[0]
         if isinstance(prompt, bytes):
             prompt = prompt.decode("utf-8")
+        prompt = {"prompt": prompt}
 
         # image
         images = pb_utils.get_input_tensor_by_name(self.triton_request, "image")
@@ -106,10 +109,7 @@ class GenerateRequest(RequestBase):
                 image_rgb = Image.open(BytesIO(image_b)).convert("RGB")
                 images_vllm.append(image_rgb)
             if len(images_vllm) > 0:
-                prompt = {
-                    "prompt": prompt,
-                    "multi_modal_data": {"image": images_vllm},
-                }
+                prompt["multi_modal_data"] = {"image": images_vllm}
 
         # stream
         stream = pb_utils.get_input_tensor_by_name(self.triton_request, "stream")
@@ -182,8 +182,9 @@ class GenerateRequest(RequestBase):
             lora_local_path = self.lora_repository[lora_name]
             lora_request = LoRARequest(lora_id, lora_int_id, lora_local_path)
 
+        (engine_input,) = await self.renderer_callback([prompt])
         response_iterator = self.executor_callback(
-            prompt, sampling_params, self.id, lora_request=lora_request
+            engine_input, sampling_params, self.id, lora_request=lora_request
         )
 
         async for response in response_iterator:


### PR DESCRIPTION
### Description

Render text and multimodal completion prompts with the vLLM engine renderer before calling `AsyncLLM.generate`.

The Triton vLLM backend currently passes raw string or dictionary prompts directly to `AsyncLLM.generate`. With the vLLM version included in Triton 26.07, this uses a deprecated input path and emits a warning for each request. This change passes the renderer output to `generate` without changing the Triton request or response contract.

Related issue: triton-inference-server/server#8924

### Changes

- Pass the engine renderer callback to `GenerateRequest`.
- Build the existing text or multimodal completion prompt and render it before generation.
- Fail the targeted L0 test if the raw-prompt deprecation warning appears in the server log.

### Testing

- Triton 26.07 with vLLM 0.24.0.
- Baseline and rendered-input paths returned the same deterministic text output.
- The baseline emitted the raw-prompt deprecation warning; the rendered-input path did not.
- Qwen3-0.6B targeted vLLM backend L0 tests: 7 passed, 0 errors, 0 failures.
- Qwen3.5-9B text and multimodal generation smoke tests completed successfully.

### CLA

- Submitted the signed Triton CLA as an individual contributor.
